### PR TITLE
fix: enable ResponseErrorHandler to read both known gdc error json structures

### DIFF
--- a/src/main/java/com/gooddata/GoodDataRestException.java
+++ b/src/main/java/com/gooddata/GoodDataRestException.java
@@ -1,11 +1,11 @@
 /**
- * Copyright (C) 2004-2016, GoodData(R) Corporation. All rights reserved.
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
  * This source code is licensed under the BSD-style license found in the
  * LICENSE.txt file in the root directory of this source tree.
  */
 package com.gooddata;
 
-import com.gooddata.gdc.GdcError;
+import com.gooddata.gdc.ErrorStructure;
 
 /**
  * Signals client or server error during communication with GoodData REST API.
@@ -66,7 +66,7 @@ public class GoodDataRestException extends GoodDataException {
      * @param statusText the HTTP status text of the response
      * @param error      the GoodData REST API error structure
      */
-    public GoodDataRestException(int statusCode, String requestId, String statusText, GdcError error) {
+    public GoodDataRestException(int statusCode, String requestId, String statusText, ErrorStructure error) {
         this(statusCode,
                 error != null && error.getRequestId() != null ? error.getRequestId() : requestId,
                 error != null && error.getMessage() != null ? error.getFormattedMessage() : statusText,

--- a/src/main/java/com/gooddata/gdc/ErrorStructure.java
+++ b/src/main/java/com/gooddata/gdc/ErrorStructure.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2004-2016, GoodData(R) Corporation. All rights reserved.
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
  * This source code is licensed under the BSD-style license found in the
  * LICENSE.txt file in the root directory of this source tree.
  */
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import static com.gooddata.util.Validate.notNull;
 import static java.util.Arrays.copyOf;
@@ -18,6 +19,7 @@ import static java.util.Arrays.copyOf;
  * Deserialization only.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = ErrorStructureDeserializer.class)
 public class ErrorStructure {
     protected final String message;
     protected final Object[] parameters;

--- a/src/main/java/com/gooddata/gdc/ErrorStructureDeserializer.java
+++ b/src/main/java/com/gooddata/gdc/ErrorStructureDeserializer.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.gdc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
+import java.io.IOException;
+
+/**
+ * Common deserializer for {@link ErrorStructure} and {@link GdcError}.
+ */
+class ErrorStructureDeserializer extends JsonDeserializer<ErrorStructure> {
+
+    private static final String GDC_ERROR_TYPE_NAME = "error";
+
+    @Override
+    public ErrorStructure deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        final TokenBuffer tokenBuffer = new TokenBuffer(jp);
+        tokenBuffer.copyCurrentStructure(jp);
+
+        final TreeNode treeNode = tokenBuffer.asParser().readValueAsTree();
+
+        Class<? extends ErrorStructure> clazz;
+        if (treeNode.isObject()) {
+            if (((ObjectNode) treeNode).has(GDC_ERROR_TYPE_NAME)) {
+                clazz = GdcError.class;
+            } else {
+                clazz = DefaultDeserializerErrorStructure.class;
+            }
+        } else {
+            throw ctxt.mappingException("Unknown type of ErrorStructure");
+        }
+
+        final JsonParser nextParser = tokenBuffer.asParser();
+        nextParser.nextToken(); // just created parser points before the first token
+
+        return ctxt.readValue(nextParser, clazz);
+    }
+
+    /**
+     * This class actually represents deserialized {@link ErrorStructure}.
+     * We need to override deserializer to break the cycle while deserialize.
+     */
+    @JsonDeserialize(using = None.class)
+    private static class DefaultDeserializerErrorStructure extends ErrorStructure {
+
+        protected DefaultDeserializerErrorStructure(@JsonProperty("errorClass") String errorClass,
+                                                    @JsonProperty("component") String component,
+                                                    @JsonProperty("parameters") Object[] parameters,
+                                                    @JsonProperty("message") String message,
+                                                    @JsonProperty("errorCode") String errorCode,
+                                                    @JsonProperty("errorId") String errorId,
+                                                    @JsonProperty("trace") String trace,
+                                                    @JsonProperty("requestId") String requestId) {
+            super(errorClass, component, parameters, message, errorCode, errorId, trace, requestId);
+        }
+    }
+}

--- a/src/main/java/com/gooddata/gdc/GdcError.java
+++ b/src/main/java/com/gooddata/gdc/GdcError.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * GoodData REST API error structure.
@@ -20,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 public class GdcError extends ErrorStructure {
 
     @JsonCreator

--- a/src/main/java/com/gooddata/util/ResponseErrorHandler.java
+++ b/src/main/java/com/gooddata/util/ResponseErrorHandler.java
@@ -1,12 +1,12 @@
 /**
- * Copyright (C) 2004-2016, GoodData(R) Corporation. All rights reserved.
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
  * This source code is licensed under the BSD-style license found in the
  * LICENSE.txt file in the root directory of this source tree.
  */
 package com.gooddata.util;
 
 import com.gooddata.GoodDataRestException;
-import com.gooddata.gdc.GdcError;
+import com.gooddata.gdc.ErrorStructure;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.client.DefaultResponseErrorHandler;
@@ -24,16 +24,16 @@ import static com.gooddata.util.Validate.noNullElements;
  */
 public class ResponseErrorHandler extends DefaultResponseErrorHandler {
 
-    private final HttpMessageConverterExtractor<GdcError> gdcErrorExtractor;
+    private final HttpMessageConverterExtractor<ErrorStructure> gdcErrorExtractor;
 
     public ResponseErrorHandler(List<HttpMessageConverter<?>> messageConverters) {
-        gdcErrorExtractor = new HttpMessageConverterExtractor<>(GdcError.class,
+        gdcErrorExtractor = new HttpMessageConverterExtractor<>(ErrorStructure.class,
                 noNullElements(messageConverters, "messageConverters"));
     }
 
     @Override
     public void handleError(ClientHttpResponse response) {
-        GdcError error = null;
+        ErrorStructure error = null;
         try {
             error = gdcErrorExtractor.extractData(response);
         } catch (RestClientException | IOException ignored) {

--- a/src/test/java/com/gooddata/util/ResponseErrorHandlerTest.java
+++ b/src/test/java/com/gooddata/util/ResponseErrorHandlerTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gooddata.GoodData;
+import com.gooddata.GoodDataRestException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+public class ResponseErrorHandlerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private ResponseErrorHandler responseErrorHandler;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        responseErrorHandler = new ResponseErrorHandler(singletonList(new MappingJackson2HttpMessageConverter(OBJECT_MAPPER)));
+    }
+
+    @Test
+    public void testHandleGdcError() throws Exception {
+        final ClientHttpResponse response = prepareResponse("/gdc/gdcError.json");
+
+        final GoodDataRestException exc = assertException(() -> responseErrorHandler.handleError(response));
+
+        assertThat("GoodDataRestException should have been thrown!", exc, is(notNullValue()));
+        assertEquals(exc.getStatusCode(), 500);
+        assertEquals(exc.getRequestId(), "REQ");
+        assertEquals(exc.getComponent(), "COMPONENT");
+        assertEquals(exc.getErrorClass(), "CLASS");
+        assertEquals(exc.getErrorCode(), "CODE");
+        assertEquals(exc.getText(), "MSG");
+    }
+
+    @Test
+    public void testHandleErrorStructure() throws Exception {
+        final ClientHttpResponse response = prepareResponse("/gdc/errorStructure.json");
+
+        final GoodDataRestException exc = assertException(() -> responseErrorHandler.handleError(response));
+
+        assertThat("GoodDataRestException should have been thrown!", exc, is(notNullValue()));
+        assertEquals(exc.getStatusCode(), 500);
+        assertEquals(exc.getRequestId(), "REQ");
+        assertEquals(exc.getComponent(), "COMPONENT");
+        assertEquals(exc.getErrorClass(), "CLASS");
+        assertEquals(exc.getErrorCode(), "CODE");
+        assertEquals(exc.getText(), "MSG PARAM1 PARAM2 3");
+    }
+
+    private ClientHttpResponse prepareResponse(String resourcePath) throws IOException {
+        final ClientHttpResponse response = mock(ClientHttpResponse.class);
+        when(response.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+        when(response.getRawStatusCode()).thenReturn(500);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set(GoodData.GDC_REQUEST_ID_HEADER, "requestId");
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        when(response.getHeaders()).thenReturn(headers);
+        when(response.getBody()).thenReturn(getClass().getResourceAsStream(resourcePath));
+
+        return response;
+    }
+
+    private static GoodDataRestException assertException(Runnable runnable) {
+        try {
+            runnable.run();
+            return null;
+        } catch (GoodDataRestException e) {
+            return e;
+        }
+    }
+
+}


### PR DESCRIPTION
Resolves #395.

Custom deserializer for ErrorStructure and descendant GdcError created. Unfortunately it's not possible to
deserialize exactly the ErrorStructure instance - the on purpose descendant is returned instead.