### PR TITLE
Add Pitest to build (verify phase)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <json-unit.version>1.5.3</json-unit.version>
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <currentYear>${maven.build.timestamp}</currentYear>
+        <pitest.mutationThreshold>65</pitest.mutationThreshold>
     </properties>
 
     <build>
@@ -187,6 +188,30 @@
                     </execution>
                 </executions>
                 <!-- add missing license: mvn com.mycila:license-maven-plugin:3.0:format -->
+            </plugin>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.1.11</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>mutationCoverage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <targetTests>
+                        <targetTest>*Test</targetTest>
+                    </targetTests>
+                    <excludedMethods>
+                        <excludedMethod>equals</excludedMethod>
+                        <excludedMethod>hashCode</excludedMethod>
+                    </excludedMethods>
+                    <threads>8</threads>
+                    <mutationThreshold>${pitest.mutationThreshold}</mutationThreshold>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -400,6 +425,13 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- just for pitest-maven plugin -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.21</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/gooddata/AbstractGoodDataAT.java
+++ b/src/test/java/com/gooddata/AbstractGoodDataAT.java
@@ -31,7 +31,7 @@ public abstract class AbstractGoodDataAT {
                     new GoodDataEndpoint(getProperty("host")),
                     new LoginPasswordAuthentication(getProperty("login"), getProperty("pass")) {
                         /**
-                         * had to be overriden to access connectionManager, to test how many connections were not closed
+                         * had to be overridden to access connectionManager, to test how many connections were not closed
                          */
                         @Override
                         public HttpClient createHttpClient(final GoodDataEndpoint endpoint, final HttpClientBuilder builder) {

--- a/src/test/java/com/gooddata/warehouse/WarehouseNotFoundExceptionTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseNotFoundExceptionTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+package com.gooddata.warehouse;
+
+import com.gooddata.GoodDataRestException;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class WarehouseNotFoundExceptionTest {
+
+    @Test
+    public void testGetWarehouseUri() throws Exception {
+        final WarehouseNotFoundException exception = new WarehouseNotFoundException("TEST",
+                mock(GoodDataRestException.class));
+        assertThat(exception.getWarehouseUri(), is("TEST"));
+    }
+
+}

--- a/src/test/java/com/gooddata/warehouse/WarehouseSchemaNotFoundExceptionTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseSchemaNotFoundExceptionTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+package com.gooddata.warehouse;
+
+import com.gooddata.GoodDataRestException;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class WarehouseSchemaNotFoundExceptionTest {
+
+    @Test
+    public void testGetWarehouseSchemaUri() throws Exception {
+        final WarehouseSchemaNotFoundException exception = new WarehouseSchemaNotFoundException("TEST",
+                mock(GoodDataRestException.class));
+        assertThat(exception.getWarehouseSchemaUri(), is("TEST"));
+    }
+
+}

--- a/src/test/java/com/gooddata/warehouse/WarehouseServiceTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseServiceTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+package com.gooddata.warehouse;
+
+import com.gooddata.FutureResult;
+import com.gooddata.collections.Page;
+import com.gooddata.collections.PageableList;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class WarehouseServiceTest {
+
+    private static final String WAREHOUSES_URL = "/gdc/datawarehouse/instances";
+    private static final String WAREHOUSE_URL = "/gdc/datawarehouse/instances/17";
+    private static final String WAREHOUSE_ID = "17";
+    private static final String SCHEMAS_URL = "/gdc/datawarehouse/instances/17/schemas";
+
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private Warehouse warehouse;
+
+    private WarehouseService service;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(warehouse.getUri()).thenReturn(WAREHOUSE_URL);
+        when(warehouse.getId()).thenReturn(WAREHOUSE_ID);
+        service = new WarehouseService(restTemplate);
+    }
+
+    @Test
+    public void testCreateWarehouse() throws Exception {
+        final WarehouseTask warehouseTask = mock(WarehouseTask.class);
+        when(restTemplate.postForObject(WAREHOUSES_URL, warehouse, WarehouseTask.class))
+                .thenReturn(warehouseTask);
+        when(warehouseTask.getPollUri()).thenReturn("TEST_POLL_URI");
+
+        final FutureResult<Warehouse> result = service.createWarehouse(warehouse);
+
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testRemoveWarehouse() throws Exception {
+        service.removeWarehouse(warehouse);
+        verify(restTemplate).delete(WAREHOUSE_URL);
+        verify(warehouse).getUri();
+    }
+
+    @Test
+    public void testGetWarehouseByUri() throws Exception {
+        when(restTemplate.getForObject("test-uri", Warehouse.class)).thenReturn(warehouse);
+        assertThat(service.getWarehouseByUri("test-uri"), is(warehouse));
+    }
+
+    @Test
+    public void testGetWarehouseById() throws Exception {
+        when(restTemplate.getForObject(WAREHOUSE_URL, Warehouse.class)).thenReturn(warehouse);
+        assertThat(service.getWarehouseById("17"), is(warehouse));
+    }
+
+    @Test
+    public void testListWarehouses() throws Exception {
+        when(restTemplate.getForObject(WAREHOUSES_URL, Warehouses.class)).thenReturn(mock(Warehouses.class));
+
+        final PageableList<Warehouse> result = service.listWarehouses();
+
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testListWarehousesWithPage() throws Exception {
+        final Page page = mock(Page.class);
+        when(restTemplate.getForObject(WAREHOUSES_URL, Warehouses.class)).thenReturn(mock(Warehouses.class));
+
+        final PageableList<Warehouse> result = service.listWarehouses(page);
+
+        assertThat(result, is(notNullValue()));
+        verify(page).getPageUri(any());
+    }
+
+    @Test
+    public void testListWarehouseUsers() throws Exception {
+        final Page page = mock(Page.class);
+        final PageableList<WarehouseUser> result = service.listWarehouseUsers(warehouse, page);
+
+        assertThat(result, is(notNullValue()));
+        verify(page).getPageUri(any());
+    }
+
+    @Test
+    public void testAddUserToWarehouse() throws Exception {
+        final WarehouseUser user = mock(WarehouseUser.class);
+        final WarehouseTask warehouseTask = mock(WarehouseTask.class);
+        when(restTemplate.postForObject(WAREHOUSES_URL + "/{id}/users", user, WarehouseTask.class, WAREHOUSE_ID))
+                .thenReturn(warehouseTask);
+        when(warehouseTask.getPollUri()).thenReturn("TEST_POLL_URI");
+
+        final FutureResult<WarehouseUser> result = service.addUserToWarehouse(warehouse, user);
+
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testRemoveUserFromWarehouse() throws Exception {
+        final WarehouseUser user = mock(WarehouseUser.class);
+        when(user.getUri()).thenReturn("TEST_USER_URI");
+        final WarehouseTask warehouseTask = mock(WarehouseTask.class);
+        when(warehouseTask.getPollUri()).thenReturn("TEST_POLL_URI");
+        final ResponseEntity entity = mock(ResponseEntity.class);
+        when(entity.getBody()).thenReturn(warehouseTask);
+        when(restTemplate.exchange("TEST_USER_URI", HttpMethod.DELETE, null, WarehouseTask.class)).thenReturn(entity);
+
+        final FutureResult<Void> result = service.removeUserFromWarehouse(user);
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testUpdateWarehouse() throws Exception {
+        final Warehouse updatedWarehouse = mock(Warehouse.class);
+        when(restTemplate.getForObject(WAREHOUSE_URL, Warehouse.class)).thenReturn(updatedWarehouse);
+
+        final Warehouse result = service.updateWarehouse(this.warehouse);
+
+        verify(restTemplate).put(WAREHOUSE_URL, this.warehouse);
+        assertThat(result, is(updatedWarehouse));
+    }
+
+    @Test
+    public void testListWarehouseSchemas() throws Exception {
+        when(restTemplate.getForObject(SCHEMAS_URL, WarehouseSchemas.class)).thenReturn(mock(WarehouseSchemas.class));
+
+        final PageableList<WarehouseSchema> result = service.listWarehouseSchemas(warehouse);
+
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void testGetWarehouseSchemaByName() throws Exception {
+        final WarehouseSchema schema = mock(WarehouseSchema.class);
+        when(restTemplate.getForObject(SCHEMAS_URL + "/TEST_NAME", WarehouseSchema.class)).thenReturn(schema);
+        final WarehouseSchema result = service.getWarehouseSchemaByName(warehouse, "TEST_NAME");
+
+        assertThat(result, is(schema));
+    }
+
+    @Test
+    public void testGetWarehouseSchemaByUri() throws Exception {
+        final WarehouseSchema schema = mock(WarehouseSchema.class);
+        when(restTemplate.getForObject(SCHEMAS_URL + "/TEST_NAME", WarehouseSchema.class)).thenReturn(schema);
+        final WarehouseSchema result = service.getWarehouseSchemaByUri(SCHEMAS_URL + "/TEST_NAME");
+
+        assertThat(result, is(schema));
+    }
+
+    @Test
+    public void testGetDefaultWarehouseSchema() throws Exception {
+        final WarehouseSchema schema = mock(WarehouseSchema.class);
+        when(restTemplate.getForObject(SCHEMAS_URL + "/default", WarehouseSchema.class)).thenReturn(schema);
+        final WarehouseSchema result = service.getDefaultWarehouseSchema(warehouse);
+        assertThat(result, is(schema));
+    }
+
+}

--- a/src/test/java/com/gooddata/warehouse/WarehouseUserNotFoundExceptionTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseUserNotFoundExceptionTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+package com.gooddata.warehouse;
+
+import com.gooddata.GoodDataRestException;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.*;
+
+public class WarehouseUserNotFoundExceptionTest {
+
+    @Test
+    public void testGetUserUri() throws Exception {
+        final WarehouseUserNotFoundException exception = new WarehouseUserNotFoundException("TEST",
+                mock(GoodDataRestException.class));
+        assertThat(exception.getUserUri(), is("TEST"));
+    }
+
+}


### PR DESCRIPTION
Mutation testing for better unit tests coverage evaluation.

FYI:
* can't run on *AT, since they need backend
* to run with *IT it adds a few percents to coverage, but it takes + 12minutes to run! (Generated 1951 mutations Killed 1352 (69%), Ran 10822 tests (5.55 tests per mutation))
* using 8 threads, it (just *Test) takes 2minutes (using 1 thread takes 4.5 minutes) (Generated 1951 mutations Killed 1118 (57%), Ran 5208 tests (2.67 tests per mutation))
* after exclusion of `equals` and `hashCode` it improved to: Generated 1612 mutations Killed 1050 (65%), Ran 4599 tests (2.85 tests per mutation)

If merged, I would add to https://github.com/gooddata/gooddata-java/wiki/Testing:

> ## Unit tests coverage using mutation testing
> 
> Invoked by issuing command:
> ```
> mvn -DwithHistory org.pitest:pitest-maven:mutationCoverage
> ```
> For more details, see HTML report in `target/pit-reports/YYYYMMDDHHMI/index.html`. Current mutation score threshold at which to fail build is defined in `pitest.mutationThreshold` property in `pom.xml`.
> 