### PR TITLE
iterate/stream over multiple pages with MultiPageList, closes #479

### DIFF
--- a/src/main/java/com/gooddata/collections/MultiPageList.java
+++ b/src/main/java/com/gooddata/collections/MultiPageList.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.collections;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.Validate.notNull;
+
+/**
+ * Adapter over PageableList to offer easy iteration/streaming over multiple pages,
+ * lazily loading of pages using specified pageProvider.
+ */
+public class MultiPageList<T> extends PageableList<T> {
+    private final PageableList<T> delegate;
+    private final Function<Page, PageableList<T>> pageProvider;
+
+    /**
+     * To list all the pages, starting with the very first one.
+     *
+     * @param pageProvider provider used to load the pages
+     */
+    public MultiPageList(final Function<Page, PageableList<T>> pageProvider) {
+        this(new PageRequest(), pageProvider);
+    }
+
+    /**
+     * To list all the pages, starting with the startPage specified.
+     *
+     * @param startPage    page to start with
+     * @param pageProvider provider used to load the pages
+     */
+    public MultiPageList(final Page startPage, final Function<Page, PageableList<T>> pageProvider) {
+        this(notNull(pageProvider, "pageProvider can't be null").apply(startPage), pageProvider);
+    }
+
+    MultiPageList(final PageableList<T> delegate,
+                  final Function<Page, PageableList<T>> pageProvider) {
+        this.delegate = notNull(delegate, "delegate can't be null");
+        this.pageProvider = notNull(pageProvider, "pageProvider can't be null");
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new PageIterator<>(delegate, pageProvider);
+    }
+
+    /**
+     * Iterate over multiple pages and collect the results to list
+     *
+     * @return list with all the results
+     */
+    @Override
+    public List<T> collectAll() {
+        return stream().collect(toList());
+    }
+
+    /**
+     * Returns description of the next page.
+     *
+     * @return next page, might be <code>null</code>
+     */
+    @Override
+    public Page getNextPage() {
+        return delegate.getNextPage();
+    }
+
+    /**
+     * Signals whether there are more subsequent pages or the last page has been reached
+     * @return true if there are more results to come
+     */
+    @Override
+    public boolean hasNextPage() {
+        return delegate.hasNextPage();
+    }
+
+    /**
+     * Returns map of links.
+     *
+     * @return map of links, might be <code>null</code>
+     */
+    @Override
+    public Map<String, String> getLinks() {
+        return delegate.getLinks();
+    }
+
+    /**
+     * Returns description of the current collection page.
+     *
+     * @return current collection page, might be <code>null</code>
+     */
+    @Override
+    public Paging getPaging() {
+        return delegate.getPaging();
+    }
+
+    /**
+     * Returns size of the items collection on a current page. If you need the size of entire collection
+     * across all pages, use <code>totalSize()</code> instead.
+     *
+     * @return size of the items collection on a current page
+     */
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    /**
+     * Returns size of entire collection across all pages. It will fetch all the pages, so use wisely.
+     * @return size of entire collection across all pages
+     */
+    public int totalSize() {
+        return (int) stream().count();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    /**
+     * Whether current page contains the specified object. If you need to verify whether entire collection
+     * across all pages contains the object, use <code>stream().anyMatch(o)</code> instead.
+     */
+    @Override
+    public boolean contains(final Object o) {
+        return delegate.contains(o);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(final T[] a) {
+        return delegate.toArray(a);
+    }
+
+    @Override
+    public boolean add(final T item) {
+        return delegate.add(item);
+    }
+
+    @Override
+    public boolean remove(final Object o) {
+        return delegate.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(final Collection<?> c) {
+        return delegate.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(final Collection<? extends T> c) {
+        return delegate.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(final int index, final Collection<? extends T> c) {
+        return delegate.addAll(index, c);
+    }
+
+    @Override
+    public boolean removeAll(final Collection<?> c) {
+        return delegate.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(final Collection<?> c) {
+        return delegate.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public T get(final int index) {
+        return delegate.get(index);
+    }
+
+    @Override
+    public T set(final int index, final T element) {
+        return delegate.set(index, element);
+    }
+
+    @Override
+    public void add(final int index, final T element) {
+        delegate.add(index, element);
+    }
+
+    @Override
+    public T remove(final int index) {
+        return delegate.remove(index);
+    }
+
+    @Override
+    public int indexOf(final Object o) {
+        return delegate.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(final Object o) {
+        return delegate.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<T> listIterator() {
+        return delegate.listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(final int index) {
+        return delegate.listIterator(index);
+    }
+
+    @Override
+    public List<T> subList(final int fromIndex, final int toIndex) {
+        return delegate.subList(fromIndex, toIndex);
+    }
+
+    private static final class PageIterator<T> implements Iterator<T> {
+
+        private PageableList<T> currentPage;
+        private Iterator<T> pageItemsIterator;
+        private final Function<Page, PageableList<T>> pageProvider;
+
+        PageIterator(final PageableList<T> currentPage, final Function<Page, PageableList<T>> pageProvider) {
+            this.pageProvider = pageProvider;
+            this.currentPage = currentPage;
+            this.pageItemsIterator = currentPage.getItemsIterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (pageItemsIterator.hasNext()) {
+                return true;
+            }
+
+            if (currentPage.getNextPage() == null) {
+                return false;
+            }
+
+            final PageableList<T> next = pageProvider.apply(currentPage.getNextPage());
+            if (currentPage.getNextPage().equals(next.getNextPage())) {
+                throw new IllegalStateException("page provider does not iterate properly, returns the same page");
+            }
+
+            if (next.isEmpty() && next.getNextPage() != null) {
+                throw new IllegalStateException("page has no results, yet claims there is next page");
+            }
+
+            currentPage = next;
+            pageItemsIterator = currentPage.getItemsIterator();
+
+            return pageItemsIterator.hasNext();
+        }
+
+        @Override
+        public T next() {
+            if (!pageItemsIterator.hasNext()) {
+                throw new NoSuchElementException("no more items left");
+            }
+
+            return pageItemsIterator.next();
+        }
+    }
+}

--- a/src/main/java/com/gooddata/collections/PageRequest.java
+++ b/src/main/java/com/gooddata/collections/PageRequest.java
@@ -5,6 +5,7 @@
  */
 package com.gooddata.collections;
 
+import com.gooddata.util.GoodDataToStringBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -106,6 +107,11 @@ public class PageRequest implements Page {
         }
         uriBuilder.replaceQueryParam("limit", limit);
         return uriBuilder;
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
     }
 
     @Override

--- a/src/main/java/com/gooddata/collections/PageableList.java
+++ b/src/main/java/com/gooddata/collections/PageableList.java
@@ -60,6 +60,13 @@ public class PageableList<E> implements List<E> {
     }
 
     /**
+     * @return all items as list
+     */
+    public List<E> collectAll() {
+        return items;
+    }
+
+    /**
      * Returns description of the next page.
      *
      * @return next page, might be <code>null</code>
@@ -94,6 +101,11 @@ public class PageableList<E> implements List<E> {
         return paging;
     }
 
+    /**
+     * Returns size of the items collection on a current page.
+     *
+     * @return size of the items collection on a current page
+     */
     @Override
     public int size() {
         return items.size();
@@ -104,6 +116,9 @@ public class PageableList<E> implements List<E> {
         return items.isEmpty();
     }
 
+    /**
+     * Whether current page items contain the specified object.
+     */
     @Override
     public boolean contains(final Object o) {
         return items.contains(o);
@@ -207,5 +222,29 @@ public class PageableList<E> implements List<E> {
     @Override
     public List<E> subList(final int fromIndex, final int toIndex) {
         return items.subList(fromIndex, toIndex);
+    }
+
+    Iterator<E> getItemsIterator() {
+        return items.iterator();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final PageableList<?> that = (PageableList<?>) o;
+
+        if (!items.equals(that.items)) return false;
+        if (!getPaging().equals(that.getPaging())) return false;
+        return getLinks().equals(that.getLinks());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = items.hashCode();
+        result = 31 * result + getPaging().hashCode();
+        result = 31 * result + getLinks().hashCode();
+        return result;
     }
 }

--- a/src/main/java/com/gooddata/collections/PageableListSerializer.java
+++ b/src/main/java/com/gooddata/collections/PageableListSerializer.java
@@ -39,7 +39,9 @@ public abstract class PageableListSerializer extends JsonSerializer<PageableList
 
         jgen.writeStartArray();
         final ObjectCodec codec = jgen.getCodec();
-        for (Object item: value) {
+
+        // only serialize current page items, do not iterate over other pages
+        for (final Object item: value.subList(0, value.size())) {
             codec.writeValue(jgen, item);
         }
         jgen.writeEndArray();

--- a/src/main/java/com/gooddata/collections/UriPage.java
+++ b/src/main/java/com/gooddata/collections/UriPage.java
@@ -5,6 +5,7 @@
  */
 package com.gooddata.collections;
 
+import com.gooddata.util.GoodDataToStringBuilder;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
@@ -61,5 +62,25 @@ class UriPage implements Page {
             uriBuilder.replaceQueryParam(entry.getKey(), entry.getValue().toArray());
         }
         return uriBuilder;
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final UriPage uriPage = (UriPage) o;
+
+        return pageUri != null ? pageUri.equals(uriPage.pageUri) : uriPage.pageUri == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return pageUri != null ? pageUri.hashCode() : 0;
     }
 }

--- a/src/main/java/com/gooddata/dataload/processes/ProcessService.java
+++ b/src/main/java/com/gooddata/dataload/processes/ProcessService.java
@@ -13,7 +13,9 @@ import com.gooddata.GoodDataException;
 import com.gooddata.GoodDataRestException;
 import com.gooddata.SimplePollHandler;
 import com.gooddata.account.AccountService;
+import com.gooddata.collections.MultiPageList;
 import com.gooddata.collections.Page;
+import com.gooddata.collections.PageRequest;
 import com.gooddata.collections.PageableList;
 import com.gooddata.gdc.DataStoreService;
 import com.gooddata.project.Project;
@@ -436,24 +438,24 @@ public class ProcessService extends AbstractService {
      * Get first page of paged list of schedules by given project.
      *
      * @param project project of schedules
-     * @return list of found schedules or empty list
+     * @return MultiPageList list of found schedules or empty list
      */
-    public PageableList<Schedule> listSchedules(Project project) {
-        notNull(project, "project");
-        return listSchedules(getSchedulesUri(project));
+    public PageableList<Schedule> listSchedules(final Project project) {
+        return listSchedules(project, new PageRequest());
     }
 
     /**
      * Get defined page of paged list of schedules by given project.
      *
-     * @param project project of schedules
-     * @param page    page to be retrieved
-     * @return list of found schedules or empty list
+     * @param project   project of schedules
+     * @param startPage page to be retrieved
+     * @return MultiPageList list of found schedules or empty list
      */
-    public PageableList<Schedule> listSchedules(Project project, Page page) {
+    public PageableList<Schedule> listSchedules(final Project project,
+                                                final Page startPage) {
         notNull(project, "project");
-        notNull(page, "page");
-        return listSchedules(page.getPageUri(UriComponentsBuilder.fromUri(getSchedulesUri(project))));
+        notNull(startPage, "startPage");
+        return new MultiPageList<>(startPage, page -> listSchedules(getSchedulesUri(project, page)));
     }
 
     /**
@@ -520,8 +522,12 @@ public class ProcessService extends AbstractService {
         return Schedule.TEMPLATE.expand(project.getId(), id);
     }
 
-    private static URI getSchedulesUri(Project project) {
+    private static URI getSchedulesUri(final Project project) {
         return Schedules.TEMPLATE.expand(project.getId());
+    }
+
+    private static URI getSchedulesUri(final Project project, final Page page) {
+        return page.getPageUri(UriComponentsBuilder.fromUri(getSchedulesUri(project)));
     }
 
     private Schedule postSchedule(Schedule schedule, URI postUri) {

--- a/src/main/java/com/gooddata/project/ProjectService.java
+++ b/src/main/java/com/gooddata/project/ProjectService.java
@@ -13,6 +13,7 @@ import com.gooddata.GoodDataRestException;
 import com.gooddata.PollResult;
 import com.gooddata.SimplePollHandler;
 import com.gooddata.account.AccountService;
+import com.gooddata.collections.MultiPageList;
 import com.gooddata.collections.Page;
 import com.gooddata.collections.PageableList;
 import com.gooddata.gdc.AsyncTask;
@@ -27,7 +28,6 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static com.gooddata.util.Validate.notEmpty;
@@ -266,27 +266,27 @@ public class ProjectService extends AbstractService {
      * Get first page of paged list of users by given project.
      *
      * @param project project of users
-     * @return list of found users or empty list
+     * @return MultiPageList list of found users or empty list
      */
-    public List<User> listUsers(Project project) {
+    public PageableList<User> listUsers(final Project project) {
         notNull(project, "project");
-        return listUsers(getUsersUri(project));
+        return new MultiPageList<>(page -> listUsers(getUsersUri(project, page)));
     }
 
     /**
      * Get defined page of paged list of users by given project.
      *
-     * @param project project of users
-     * @param page    page to be retrieved
-     * @return list of found users or empty list
+     * @param project   project of users
+     * @param startPage page to be retrieved first
+     * @return MultiPageList list of found users or empty list
      */
-    public List<User> listUsers(Project project, Page page) {
+    public PageableList<User> listUsers(final Project project, final Page startPage) {
         notNull(project, "project");
-        notNull(page, "page");
-        return listUsers(page.getPageUri(fromUri(getUsersUri(project))));
+        notNull(startPage, "startPage");
+        return new MultiPageList<>(startPage, page -> listUsers(getUsersUri(project, page)));
     }
 
-    private PageableList<User> listUsers(URI uri) {
+    private PageableList<User> listUsers(final URI uri) {
         try {
             final Users users = restTemplate.getForObject(uri, Users.class);
             if (users == null) {
@@ -298,8 +298,12 @@ public class ProjectService extends AbstractService {
         }
     }
 
-    private static URI getUsersUri(Project project) {
+    private static URI getUsersUri(final Project project) {
         return Users.TEMPLATE.expand(project.getId());
+    }
+
+    private static URI getUsersUri(final Project project, final Page page) {
+        return page.getPageUri(fromUri(getUsersUri(project)));
     }
 
     /**

--- a/src/test/java/com/gooddata/collections/MultiPageListTest.java
+++ b/src/test/java/com/gooddata/collections/MultiPageListTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.collections;
+
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.fail;
+
+public class MultiPageListTest {
+    final MultiPageList<Integer> singlePageList = new MultiPageList<>(
+            new PageableList<>(singletonList(11), null),
+            page -> null
+    );
+
+    final MultiPageList<Integer> twoPageList = new MultiPageList<>(
+            new PageableList<>(singletonList(11), new Paging("nextpage2")),
+            page -> new PageableList<>(singletonList(12), null)
+    );
+
+    @Test
+    public void totalSize() {
+        assertThat(singlePageList.totalSize(), is(1));
+        assertThat(twoPageList.totalSize(), is(2));
+    }
+
+    @Test
+    public void collectAll() {
+        assertThat(singlePageList.collectAll(), is(singletonList(11)));
+        assertThat(twoPageList.collectAll(), is(asList(11, 12)));
+    }
+
+    @Test
+    public void isEmpty() {
+        assertThat(new MultiPageList<Integer>(page -> new PageableList<>()), is(empty()));
+        assertThat(singlePageList, is(not(empty())));
+        assertThat(twoPageList, is(not(empty())));
+    }
+
+    @Test
+    public void iterator() {
+        final Iterator<Integer> iterator = new MultiPageList<>(
+                new PageableList<>(singletonList(1), null),
+                page -> null
+        ).iterator();
+
+        assertThat(iterator.hasNext(), is(true));
+        assertThat(iterator.next(), is(1));
+        assertThat(iterator.hasNext(), is(false));
+        try {
+            iterator.next();
+            fail("expected NoSuchElementException");
+        } catch (final NoSuchElementException ignored) {
+        }
+    }
+
+    @Test
+    public void iteratorWithPageProvider() {
+        final PageableList<Integer> lastPage = new PageableList<>(singletonList(3), null);
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>(asList(1, 2), new Paging("next")),
+                page -> lastPage
+        );
+
+        final Iterator<Integer> iterator = list.iterator();
+        assertThat(iterator.hasNext(), is(true));
+        assertThat(iterator.next(), is(1));
+        assertThat(iterator.hasNext(), is(true));
+        assertThat(iterator.next(), is(2));
+        assertThat(iterator.hasNext(), is(true));
+        assertThat(iterator.next(), is(3));
+
+        assertThat(iterator.hasNext(), is(false));
+        try {
+            iterator.next();
+            fail("expected NoSuchElementException");
+        } catch (final NoSuchElementException ignored) {
+        }
+    }
+
+    @Test
+    public void stream() {
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>(asList(1, 2), null),
+                page -> null
+        );
+        assertThat(list.stream().max(Integer::compareTo).orElse(0), is(2));
+    }
+
+    @Test
+    public void streamWithPageProvider() {
+        final PageableList<Integer> lastPage = new PageableList<>(singletonList(3), null);
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>(asList(1, 2), new Paging("next")),
+                page -> lastPage
+        );
+
+        assertThat(list.stream().max(Integer::compareTo).orElse(0), is(3));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void infiniteLoopShouldBePrevented() {
+        final PageableList<Integer> pageableList = new PageableList<>(asList(1, 2), new Paging("next"));
+        final PageableList<Integer> list = new MultiPageList<>(
+                pageableList,
+                page -> pageableList
+        );
+
+        list.stream().anyMatch(it -> it == 5);
+    }
+
+    @Test
+    public void hasNextShouldOnlySwitchPageOnceAndOnlyOnce() {
+        final PageableList<Integer> list = new MultiPageList<>(
+                new PageableList<>(emptyList(), new Paging("page2")),
+                new SinglePageProvider(new PageableList<>(singletonList(2), new Paging("page3")))
+        );
+        final Iterator<Integer> iterator = list.iterator();
+
+        assertThat(iterator.hasNext(), is(true));
+        assertThat(iterator.hasNext(), is(true));
+
+        assertThat(iterator.next(), is(2));
+
+        try {
+            iterator.hasNext();
+            fail("expected that iterator will try to switch the page again, but it didn't happen");
+        } catch (final IllegalStateException ignored) {
+        }
+    }
+
+    @Test
+    public void testDelegateMethods() {
+        final PageableList delegate = mock(PageableList.class);
+        final MultiPageList<String> list = new MultiPageList<String>(delegate, page -> null);
+
+        list.getNextPage();
+        verify(delegate).getNextPage();
+
+        list.hasNextPage();
+        verify(delegate).hasNextPage();
+
+        list.getLinks();
+        verify(delegate).getLinks();
+
+        list.getPaging();
+        verify(delegate).getPaging();
+
+        list.size();
+        verify(delegate).size();
+
+        list.contains("x");
+        verify(delegate).contains("x");
+
+        list.toArray();
+        verify(delegate).toArray();
+
+        list.toArray(new Object[] {"x"});
+        verify(delegate).toArray(new Object[] {"x"});
+
+        list.add("a");
+        verify(delegate).add("a");
+
+        list.add(1, "a");
+        verify(delegate).add(1, "a");
+
+        list.remove(0);
+        verify(delegate).remove(0);
+
+        list.remove("b");
+        verify(delegate).remove("b");
+
+        list.clear();
+        verify(delegate).clear();
+
+        list.containsAll(asList("a", "b"));
+        verify(delegate).containsAll(asList("a", "b"));
+
+        list.addAll(asList("a", "b"));
+        verify(delegate).addAll(asList("a", "b"));
+
+        list.addAll(1, asList("a", "b"));
+        verify(delegate).addAll(1, asList("a", "b"));
+
+        list.removeAll(asList("a", "b"));
+        verify(delegate).removeAll(asList("a", "b"));
+
+        list.retainAll(asList("a", "b"));
+        verify(delegate).retainAll(asList("a", "b"));
+
+        list.set(0, "x");
+        verify(delegate).set(0, "x");
+
+        list.get(0);
+        verify(delegate).get(0);
+
+        list.indexOf("x");
+        verify(delegate).indexOf("x");
+
+        list.lastIndexOf("x");
+        verify(delegate).lastIndexOf("x");
+
+        list.listIterator();
+        verify(delegate).listIterator();
+
+        list.listIterator(1);
+        verify(delegate).listIterator(1);
+
+        list.subList(0, 1);
+        verify(delegate).subList(0, 1);
+    }
+
+    /**
+     * This provider will only provide one page, but will throw an exception when asked to provide another
+     */
+    class SinglePageProvider implements Function<Page, PageableList<Integer>> {
+        int count = 0;
+        final PageableList<Integer> page;
+
+        SinglePageProvider(final PageableList<Integer> page) {
+            this.page = page;
+        }
+
+        @Override
+        public PageableList<Integer> apply(final Page page) {
+            count++;
+            if(count > 1) {
+                throw new IllegalStateException("second page has been requested");
+            }
+
+            return this.page;
+        }
+    }
+}

--- a/src/test/java/com/gooddata/collections/PageRequestTest.java
+++ b/src/test/java/com/gooddata/collections/PageRequestTest.java
@@ -11,6 +11,7 @@ import org.testng.annotations.Test;
 import java.net.URI;
 
 import static com.gooddata.collections.PageRequest.DEFAULT_LIMIT;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -87,5 +88,23 @@ public class PageRequestTest {
     public void shouldReturnMaxForSanitizedLimit() throws Exception {
         final PageRequest pageRequest = new PageRequest(100);
         assertThat(pageRequest.getSanitizedLimit(10), is(10));
+    }
+
+    @Test
+    public void equals() {
+        assertThat(new PageRequest(), is(not(new PageRequest(10))));
+
+        assertThat(new PageRequest(10), is(new PageRequest(10)));
+        assertThat(new PageRequest(10), is(not(new PageRequest(11))));
+
+        assertThat(new PageRequest(1, 2), is(new PageRequest(1, 2)));
+        assertThat(new PageRequest(1, 2), is(new PageRequest("1", 2)));
+        assertThat(new PageRequest(1, 2), is(not(new PageRequest("meh", 2))));
+        assertThat(new PageRequest(1, 2), is(not(new PageRequest("1", 3))));
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(new PageRequest(1, 2).toString(), is("PageRequest[offset=1,limit=2]"));
     }
 }

--- a/src/test/java/com/gooddata/collections/PageableListTest.java
+++ b/src/test/java/com/gooddata/collections/PageableListTest.java
@@ -7,8 +7,7 @@ package com.gooddata.collections;
 
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,7 +27,7 @@ public class PageableListTest {
 
     @Test
     public void testCollection() {
-        final PageableList<Integer> collection = new PageableList<>(Arrays.asList(1, 2, 3), null);
+        final PageableList<Integer> collection = new PageableList<>(asList(1, 2, 3), null);
         assertThat(collection, notNullValue());
         assertThat(collection, hasSize(3));
         assertThat(collection.getNextPage(), nullValue());
@@ -36,11 +35,10 @@ public class PageableListTest {
 
     @Test
     public void testCollectionWithPaging() {
-        final PageableList<Integer> collection = new PageableList<>(Arrays.asList(1, 2, 3), new Paging("1", "next"));
+        final PageableList<Integer> collection = new PageableList<>(asList(1, 2, 3), new Paging("1", "next"));
         assertThat(collection, notNullValue());
         assertThat(collection, hasSize(3));
         assertThat(collection.getNextPage(), notNullValue());
         assertThat(collection.getNextPage().getPageUri(null).toString(), is("next"));
     }
-
 }

--- a/src/test/java/com/gooddata/collections/UriPageTest.java
+++ b/src/test/java/com/gooddata/collections/UriPageTest.java
@@ -5,6 +5,7 @@
  */
 package com.gooddata.collections;
 
+import org.hamcrest.core.Is;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.testng.annotations.Test;
@@ -14,6 +15,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
 public class UriPageTest {
@@ -68,5 +70,17 @@ public class UriPageTest {
     public void testEncoding() throws Exception {
         final UriPage uri = new UriPage("uri?test=foo%20bar");
         assertThat(uri.getPageUri(null).toString(), is("uri?test=foo%20bar"));
+    }
+
+    @Test
+    public void equals() {
+        assertThat(new UriPage("meh"), is(new UriPage("meh")));
+        assertThat(new UriPage("meh"), is(not(new UriPage("mah"))));
+    }
+
+
+    @Test
+    public void testToString() {
+        assertThat(new UriPage("abc").toString(), Is.is("UriPage[pageUri=abc]"));
     }
 }

--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
@@ -7,6 +7,7 @@ package com.gooddata.dataload.processes;
 
 import com.gooddata.AbstractGoodDataAT;
 import com.gooddata.FutureResult;
+import com.gooddata.collections.MultiPageList;
 import com.gooddata.collections.PageableList;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -165,8 +166,8 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
     public void removeSchedule() {
         gd.getProcessService().removeSchedule(schedule);
         gd.getProcessService().removeSchedule(triggeredSchedule);
-        final Collection<Schedule> schedules = gd.getProcessService().listSchedules(project);
-        assertThat(schedules, not(hasItems(hasSameScheduleIdAs(schedule), hasSameScheduleIdAs(triggeredSchedule))));
+        final MultiPageList<Schedule> schedules = (MultiPageList<Schedule>) gd.getProcessService().listSchedules(project);
+        assertThat(schedules.collectAll(), not(hasItems(hasSameScheduleIdAs(schedule), hasSameScheduleIdAs(triggeredSchedule))));
     }
 
 }

--- a/src/test/java/com/gooddata/warehouse/WarehouseServiceIT.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseServiceIT.java
@@ -7,6 +7,7 @@ package com.gooddata.warehouse;
 
 import com.gooddata.AbstractGoodDataIT;
 import com.gooddata.GoodDataException;
+import com.gooddata.collections.MultiPageList;
 import com.gooddata.collections.PageRequest;
 import com.gooddata.collections.PageableList;
 import org.hamcrest.BaseMatcher;
@@ -200,8 +201,31 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
         onRequest()
                 .havingMethodEqualTo("GET")
                 .havingPathEqualTo("/gdc/datawarehouse/instances/instanceId/users")
+                .havingParameterEqualTo("limit", "100")
+                .respond()
+                .withBody(readFromResource("/warehouse/users-with-next-page-link.json"));
+
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/gdc/datawarehouse/instances/instanceId/users")
+                .havingParameterEqualTo("offset", "profile-id-next")
+                .respond()
+                .withBody(readFromResource("/warehouse/users.json"));
+
+        final MultiPageList<WarehouseUser> users = (MultiPageList<WarehouseUser>) gd.getWarehouseService().listWarehouseUsers(warehouse);
+        assertThat(users.size(), is(2));
+        assertThat(users.totalSize(), is(4));
+        assertThat(users.collectAll().size(), is(4));
+    }
+
+
+    @Test
+    public void shouldPageUsersListWithStartPage() throws Exception {
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo("/gdc/datawarehouse/instances/instanceId/users")
                 .havingParameterEqualTo("limit", "2")
-            .respond()
+                .respond()
                 .withBody(readFromResource("/warehouse/users.json"));
 
         final PageableList<WarehouseUser> users = gd.getWarehouseService().listWarehouseUsers(warehouse, new PageRequest(2));

--- a/src/test/resources/warehouse/users-with-next-page-link.json
+++ b/src/test/resources/warehouse/users-with-next-page-link.json
@@ -1,0 +1,33 @@
+{
+  "users": {
+    "items": [
+      {
+        "user": {
+          "role": "admin",
+          "profile": "/gdc/account/profile/{profile-id}",
+          "links": {
+            "self": "/gdc/datawarehouse/instances/{instance-id}/users/{profile-id}",
+            "parent": "/gdc/datawarehouse/instances/{instance-id}/users"
+          }
+        }
+      },
+      {
+        "user": {
+          "role": "dataAdmin",
+          "profile": "/gdc/account/profile/{profile-id-2}",
+          "links": {
+            "self": "/gdc/datawarehouse/instances/{instance-id}/users/{profile-id-2}",
+            "parent": "/gdc/datawarehouse/instances/{instance-id}/users"
+          }
+        }
+      }
+    ],
+    "paging": {
+      "next": "/gdc/datawarehouse/instances/instanceId/users?offset=profile-id-next"
+    },
+    "links": {
+      "parent": "/gdc/datawarehouse/{instance-id}",
+      "self": "/gdc/datawarehouse/instances/{instance-id}/users"
+    }
+  }
+}


### PR DESCRIPTION
PageableList should be able to easily iterate over all results on multiple pages rather than making the user of PageableList worry about implementing such iteration.