### PR TITLE
fix broken hashCode/equals in PageableList

### DIFF
--- a/src/main/java/com/gooddata/collections/PageableList.java
+++ b/src/main/java/com/gooddata/collections/PageableList.java
@@ -236,15 +236,15 @@ public class PageableList<E> implements List<E> {
         final PageableList<?> that = (PageableList<?>) o;
 
         if (!items.equals(that.items)) return false;
-        if (!getPaging().equals(that.getPaging())) return false;
-        return getLinks().equals(that.getLinks());
+        if (getPaging() != null ? !getPaging().equals(that.getPaging()) : that.getPaging() != null) return false;
+        return getLinks() != null ? getLinks().equals(that.getLinks()) : that.getLinks() == null;
     }
 
     @Override
     public int hashCode() {
         int result = items.hashCode();
-        result = 31 * result + getPaging().hashCode();
-        result = 31 * result + getLinks().hashCode();
+        result = 31 * result + (getPaging() != null ? getPaging().hashCode() : 0);
+        result = 31 * result + (getLinks() != null ? getLinks().hashCode() : 0);
         return result;
     }
 }

--- a/src/test/java/com/gooddata/collections/PageableListTest.java
+++ b/src/test/java/com/gooddata/collections/PageableListTest.java
@@ -7,6 +7,8 @@ package com.gooddata.collections;
 
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -14,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 
 public class PageableListTest {
 
@@ -41,4 +44,18 @@ public class PageableListTest {
         assertThat(collection.getNextPage(), notNullValue());
         assertThat(collection.getNextPage().getPageUri(null).toString(), is("next"));
     }
+
+    @Test
+    public void testEquals() {
+        assertThat(new PageableList<>(), is(new PageableList<>()));
+        assertThat(new PageableList<>(Collections.singletonList(1), null), is(not(new PageableList<>())));
+    }
+
+
+    @Test
+    public void testHashCode() {
+        assertThat(new PageableList<>().hashCode(), is(new PageableList<>().hashCode()));
+        assertThat(new PageableList<>(Collections.singletonList(1), null).hashCode(), is(not(new PageableList<>().hashCode())));
+    }
+
 }


### PR DESCRIPTION
this fixes NPE in `hashCode()` and `equals()` due to nullable fields