### PR TITLE
add and list warehouse S3 credentials

### DIFF
--- a/src/main/java/com/gooddata/warehouse/WarehouseS3Credentials.java
+++ b/src/main/java/com/gooddata/warehouse/WarehouseS3Credentials.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.gooddata.util.GoodDataToStringBuilder;
+import com.gooddata.util.ISODateTimeDeserializer;
+import com.gooddata.util.ISODateTimeSerializer;
+import org.joda.time.DateTime;
+import org.springframework.web.util.UriTemplate;
+
+import java.util.Map;
+
+import static com.gooddata.util.Validate.notNullState;
+
+/**
+ * Single warehouse S3 credentials record (identified uniquely by warehouse ID, region and access key)
+ */
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonTypeName("s3Credentials")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WarehouseS3Credentials {
+    public static final String URI = WarehouseS3CredentialsList.URI + "/{region}/{accessKey}";
+    public static final UriTemplate TEMPLATE = new UriTemplate(URI);
+
+    private static final String SELF_LINK = "self";
+
+    private final String region;
+
+    private final String accessKey;
+
+    private final DateTime updated;
+
+    private final String updatedBy;
+
+    private final String secretKey;
+
+    private final Map<String, String> links;
+
+    /**
+     * Used to add new S3 credentials
+     *
+     * @param region    S3 region
+     * @param accessKey S3 access key
+     * @param secretKey S3 secret key
+     */
+    public WarehouseS3Credentials(final String region,
+                                  final String accessKey,
+                                  final String secretKey) {
+        this(region, accessKey, secretKey, null, null, null);
+    }
+
+    /**
+     * Used to list saved S3 credentials (not intended for the end user)
+     *
+     * @param region    S3 region
+     * @param accessKey S3 access key
+     * @param updatedBy URI of the user who updated the credentials last
+     * @param updated   last modification date
+     */
+    public WarehouseS3Credentials(final String region,
+                                  final String accessKey,
+                                  final String updatedBy,
+                                  final DateTime updated) {
+        this(region, accessKey, null, updatedBy, updated, null);
+    }
+
+    @JsonCreator
+    WarehouseS3Credentials(@JsonProperty("region") final String region,
+                           @JsonProperty("accessKey") final String accessKey,
+                           @JsonProperty("secretKey") final String secretKey,
+                           @JsonProperty("updatedBy") final String updatedBy,
+                           @JsonProperty("updated") @JsonDeserialize(using = ISODateTimeDeserializer.class) final DateTime updated,
+                           @JsonProperty("links") final Map<String, String> links) {
+        this.region = region;
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.updatedBy = updatedBy;
+        this.updated = updated;
+        this.links = links;
+    }
+
+    @JsonSerialize(using = ISODateTimeSerializer.class)
+    public DateTime getUpdated() {
+        return updated;
+    }
+
+    /**
+     * @return URI of the user who updated the credentials last
+     */
+    public String getUpdatedBy() {
+        return updatedBy;
+    }
+
+    /**
+     * not returned when listing
+     * @return S3 secret key
+     */
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    public WarehouseS3Credentials withLinks(final Map<String, String> links) {
+        return new WarehouseS3Credentials(region, accessKey, secretKey, updatedBy, updated, links);
+    }
+
+    @JsonIgnore
+    public String getUri() {
+        return notNullState(links, "links").get(SELF_LINK);
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this, "secretKey");
+    }
+}

--- a/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsList.java
+++ b/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsList.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.gooddata.collections.PageableList;
+import org.springframework.web.util.UriTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * List of warehouse S3 credentials for a given warehouse
+ */
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonTypeName("s3CredentialsList")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = WarehouseS3CredentialsListDeserializer.class)
+@JsonSerialize(using = WarehouseS3CredentialsListSerializer.class)
+public class WarehouseS3CredentialsList extends PageableList<WarehouseS3Credentials> {
+
+    static final String ROOT_NODE = "s3CredentialsList";
+    public static final String URI = Warehouse.URI + "/s3";
+    public static final UriTemplate TEMPLATE = new UriTemplate(URI);
+
+    public WarehouseS3CredentialsList(final List<WarehouseS3Credentials> items) {
+        this(items, null);
+    }
+
+    public WarehouseS3CredentialsList(final List<WarehouseS3Credentials> items,
+                               final Map<String, String> links) {
+        super(items, null, links);
+    }
+}

--- a/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsListDeserializer.java
+++ b/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsListDeserializer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import com.gooddata.collections.PageableListDeserializer;
+import com.gooddata.collections.Paging;
+
+import java.util.List;
+import java.util.Map;
+
+class WarehouseS3CredentialsListDeserializer extends PageableListDeserializer<WarehouseS3CredentialsList, WarehouseS3Credentials> {
+
+    WarehouseS3CredentialsListDeserializer() {
+        super(WarehouseS3Credentials.class);
+    }
+
+    @Override
+    protected WarehouseS3CredentialsList createList(List<WarehouseS3Credentials> items, Paging paging, Map<String, String> links) {
+        return new WarehouseS3CredentialsList(items, links);
+    }
+}

--- a/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsListSerializer.java
+++ b/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsListSerializer.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import com.gooddata.collections.PageableListSerializer;
+
+class WarehouseS3CredentialsListSerializer extends PageableListSerializer {
+
+    WarehouseS3CredentialsListSerializer() {
+        super(WarehouseS3CredentialsList.ROOT_NODE);
+    }
+}

--- a/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsNotFoundException.java
+++ b/src/main/java/com/gooddata/warehouse/WarehouseS3CredentialsNotFoundException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import com.gooddata.GoodDataException;
+import com.gooddata.GoodDataRestException;
+
+/**
+ * Thrown when specific S3 credentials, identified by warehouse ID, region and access key cannot be found
+ */
+public class WarehouseS3CredentialsNotFoundException extends GoodDataException {
+
+    private final String warehouseS3CredentialsUri;
+
+    public WarehouseS3CredentialsNotFoundException(String uri, GoodDataRestException cause) {
+        super("Warehouse S3 credentials " + uri + " not found", cause);
+        this.warehouseS3CredentialsUri = uri;
+    }
+
+    public String getWarehouseS3CredentialsUri() {
+        return this.warehouseS3CredentialsUri;
+    }
+}

--- a/src/main/java/com/gooddata/warehouse/WarehouseTask.java
+++ b/src/main/java/com/gooddata/warehouse/WarehouseTask.java
@@ -24,6 +24,7 @@ class WarehouseTask {
     private static final String POLL_LINK = "poll";
     private static final String WAREHOUSE_LINK = "instance";
     private static final String WAREHOUSE_USER_LINK = "user";
+    private static final String WAREHOUSE_S3_CREDENTIALS_LINK = "s3Credentials";
 
     private final Map<String,String> links;
 
@@ -57,5 +58,9 @@ class WarehouseTask {
 
     String getWarehouseUserUri() {
         return links.get(WAREHOUSE_USER_LINK);
+    }
+
+    String getWarehouseS3CredentialsUri() {
+        return links.get(WAREHOUSE_S3_CREDENTIALS_LINK);
     }
 }

--- a/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsListTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsListTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.gooddata.util.ResourceUtils.readObjectFromResource;
+import static java.util.Arrays.asList;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class WarehouseS3CredentialsListTest {
+
+    private final Map<String, String> credentials1Links = new HashMap<String, String>() {{
+        put("self", "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey");
+        put("parent", "/gdc/datawarehouse/instances/{instance-id}/s3");
+        put("instance", "/gdc/datawarehouse/instances/{instance-id}");
+    }};
+    private final WarehouseS3Credentials credentials1 = new WarehouseS3Credentials("region", "accessKey",
+             "secretKey", "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
+            DateTime.parse("2017-08-02T09:40:24.064Z"), credentials1Links);
+    private final WarehouseS3Credentials credentials2 = new WarehouseS3Credentials( "region2", "accessKey2",
+            "secretKey2", null, null, null);
+
+    private final Map<String, String> links = new HashMap<String, String>() {{
+        put("self", "/gdc/datawarehouse/instances/{instance-id}/s3");
+        put("parent", "/gdc/datawarehouse/instances/{instance-id}");
+    }};
+
+    private final WarehouseS3CredentialsList credentialsList = new WarehouseS3CredentialsList(
+            asList(credentials1, credentials2), links);
+
+    @Test
+    public void serialize() {
+        assertThat(credentialsList, jsonEquals(resource("warehouse/s3CredentialsList.json")));
+    }
+
+    @Test
+    public void deserialize() {
+        final WarehouseS3CredentialsList result = readObjectFromResource("/warehouse/s3CredentialsList.json",
+                WarehouseS3CredentialsList.class);
+
+        assertThat(result.size(), is(2));
+        assertThat(result.getLinks(), is(links));
+    }
+}

--- a/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.gooddata.util.ResourceUtils.readObjectFromResource;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class WarehouseS3CredentialsTest {
+
+    private static final String REGION = "region";
+    private static final String ACCESS_KEY = "accessKey";
+    private static final String UPDATED_BY = "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}";
+    private static final String SECRET_KEY = "secretKey";
+    private static final DateTime UPDATED_AT = DateTime.parse("2017-08-02T09:40:24.064Z");
+    private static final String SELF_LINK = "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey";
+    private static final String PARENT_LINK = "/gdc/datawarehouse/instances/{instance-id}/s3";
+    private static final String INSTANCE_LINK = "/gdc/datawarehouse/instances/{instance-id}";
+    private static final Map<String, String> LINKS = new HashMap<String, String>() {{
+       put("self", SELF_LINK);
+       put("parent", PARENT_LINK);
+       put("instance", INSTANCE_LINK);
+    }};
+
+    @Test
+    public void serializeFull() {
+        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, SECRET_KEY,
+                UPDATED_BY, UPDATED_AT, LINKS);
+        assertThat(credentials, jsonEquals(resource("warehouse/s3Credentials-full.json")));
+    }
+
+    @Test
+    public void serializeGet() {
+        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, UPDATED_BY,
+                UPDATED_AT);
+        assertThat(credentials, jsonEquals(resource("warehouse/s3Credentials-get.json")));
+    }
+
+    @Test
+    public void serializeCreate() {
+        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, SECRET_KEY);
+        assertThat(credentials, jsonEquals(resource("warehouse/s3Credentials-create.json")));
+    }
+
+    @Test
+    public void deserializeFull() {
+        final WarehouseS3Credentials credentials = readObjectFromResource("/warehouse/s3Credentials-full.json",
+                WarehouseS3Credentials.class);
+
+        assertThat(credentials.getRegion(), is(REGION));
+        assertThat(credentials.getAccessKey(), is(ACCESS_KEY));
+        assertThat(credentials.getUpdatedBy(), is(UPDATED_BY));
+        assertThat(credentials.getSecretKey(), is(SECRET_KEY));
+        assertThat(credentials.getUpdated().toString(), is(UPDATED_AT.toString()));
+        assertThat(credentials.getLinks(), is(LINKS));
+    }
+
+    @Test
+    public void deserializeGet() {
+        final WarehouseS3Credentials credentials = readObjectFromResource("/warehouse/s3Credentials-get.json",
+                WarehouseS3Credentials.class);
+
+        assertThat(credentials.getRegion(), is(REGION));
+        assertThat(credentials.getAccessKey(), is(ACCESS_KEY));
+        assertThat(credentials.getUpdatedBy(), is(UPDATED_BY));
+        assertThat(credentials.getSecretKey(), is(nullValue()));
+        assertThat(credentials.getUpdated().toString(), is(UPDATED_AT.toString()));
+        assertThat(credentials.getLinks(), is(nullValue()));
+    }
+
+    @Test
+    public void deserializeCreate() {
+        final WarehouseS3Credentials credentials = readObjectFromResource("/warehouse/s3Credentials-create.json",
+                WarehouseS3Credentials.class);
+
+        assertThat(credentials.getRegion(), is(REGION));
+        assertThat(credentials.getAccessKey(), is(ACCESS_KEY));
+        assertThat(credentials.getSecretKey(), is(SECRET_KEY));
+        assertThat(credentials.getUpdatedBy(), is(nullValue()));
+        assertThat(credentials.getUpdated(), is(nullValue()));
+        assertThat(credentials.getLinks(), is(nullValue()));
+    }
+
+    @Test
+    public void withLinks() {
+        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY,
+                UPDATED_BY, UPDATED_AT).withLinks(LINKS);
+        assertThat(credentials.getLinks(), is(LINKS));
+    }
+
+    @Test
+    public void getUri() {
+        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY,
+                UPDATED_BY, UPDATED_AT).withLinks(LINKS);
+
+        assertThat(credentials.getUri(), is("/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey"));
+    }
+
+    @Test
+    public void testToString() {
+        final WarehouseS3Credentials credentials = readObjectFromResource("/warehouse/s3Credentials-create.json",
+                WarehouseS3Credentials.class);
+
+        assertThat(credentials.toString(), is("WarehouseS3Credentials[region=region,accessKey=accessKey,updated=<null>,updatedBy=<null>]"));
+    }
+}

--- a/src/test/java/com/gooddata/warehouse/WarehouseTaskTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseTaskTest.java
@@ -27,6 +27,7 @@ public class WarehouseTaskTest {
         final WarehouseTask warehouseTask = readObjectFromResource("/warehouse/warehouseTask-finished.json", WarehouseTask.class);
         assertThat(warehouseTask.getWarehouseLink(), is("/gdc/datawarehouse/instances/instanceId"));
         assertThat(warehouseTask.getWarehouseUri(), is("/gdc/datawarehouse/instances/instanceId"));
+        assertThat(warehouseTask.getWarehouseS3CredentialsUri(), is("/gdc/datawarehouse/instances/instanceId/s3"));
     }
 
 }

--- a/src/test/resources/warehouse/s3Credentials-create.json
+++ b/src/test/resources/warehouse/s3Credentials-create.json
@@ -1,0 +1,7 @@
+{
+  "s3Credentials": {
+    "region": "region",
+    "accessKey": "accessKey",
+    "secretKey": "secretKey"
+  }
+}

--- a/src/test/resources/warehouse/s3Credentials-full.json
+++ b/src/test/resources/warehouse/s3Credentials-full.json
@@ -1,0 +1,14 @@
+{
+  "s3Credentials": {
+    "region": "region",
+    "accessKey": "accessKey",
+    "secretKey": "secretKey",
+    "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
+    "updated": "2017-08-02T09:40:24.064Z",
+    "links": {
+      "self": "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey",
+      "parent": "/gdc/datawarehouse/instances/{instance-id}/s3",
+      "instance": "/gdc/datawarehouse/instances/{instance-id}"
+    }
+  }
+}

--- a/src/test/resources/warehouse/s3Credentials-get.json
+++ b/src/test/resources/warehouse/s3Credentials-get.json
@@ -1,0 +1,8 @@
+{
+  "s3Credentials": {
+    "region": "region",
+    "accessKey": "accessKey",
+    "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
+    "updated": "2017-08-02T09:40:24.064Z"
+  }
+}

--- a/src/test/resources/warehouse/s3CredentialsList.json
+++ b/src/test/resources/warehouse/s3CredentialsList.json
@@ -1,0 +1,32 @@
+{
+  "s3CredentialsList": {
+    "items": [
+      {
+        "s3Credentials": {
+          "region": "region",
+          "accessKey": "accessKey",
+          "secretKey": "secretKey",
+          "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
+          "updated": "2017-08-02T09:40:24.064Z",
+          "links": {
+            "self": "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey",
+            "parent": "/gdc/datawarehouse/instances/{instance-id}/s3",
+            "instance": "/gdc/datawarehouse/instances/{instance-id}"
+          }
+        }
+      },
+      {
+        "s3Credentials": {
+          "region": "region2",
+          "accessKey": "accessKey2",
+          "secretKey": "secretKey2"
+        }
+      }
+    ],
+    "paging": {},
+    "links": {
+      "parent": "/gdc/datawarehouse/instances/{instance-id}",
+      "self": "/gdc/datawarehouse/instances/{instance-id}/s3"
+    }
+  }
+}

--- a/src/test/resources/warehouse/warehouseTask-finished.json
+++ b/src/test/resources/warehouse/warehouseTask-finished.json
@@ -3,7 +3,8 @@
         "links": {
             "instance": "/gdc/datawarehouse/instances/instanceId",
             "user": "/gdc/datawarehouse/instances/instanceId/users/userId",
-            "users": "/gdc/datawarehouse/instances/instanceId/users"
+            "users": "/gdc/datawarehouse/instances/instanceId/users",
+            "s3Credentials": "/gdc/datawarehouse/instances/instanceId/s3"
         }
     }
 }


### PR DESCRIPTION
In order to use COPY FROM S3 functionality, users need to store their S3 credentials in Vertica. This adds support for POST and GET resource to allow the users to add/list credentials.