### PR TITLE
remove updatedBy field in S3 DTO

### DIFF
--- a/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsExceptionTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsExceptionTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.warehouse;
+
+import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class WarehouseS3CredentialsExceptionTest {
+
+    public static final String URI = "/some/uri";
+
+    @Test
+    public void getUri() {
+        assertThat(new WarehouseS3CredentialsException(URI, "message").getUri(), is(URI));
+    }
+}

--- a/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsListTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsListTest.java
@@ -18,16 +18,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class WarehouseS3CredentialsListTest {
 
-    private final Map<String, String> credentials1Links = new HashMap<String, String>() {{
-        put("self", "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey");
-        put("parent", "/gdc/datawarehouse/instances/{instance-id}/s3");
-        put("instance", "/gdc/datawarehouse/instances/{instance-id}");
-    }};
+    private static final String SELF_LINK = "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey";
+    private static final String PARENT_LINK = "/gdc/datawarehouse/instances/{instance-id}/s3";
+    private static final String INSTANCE_LINK = "/gdc/datawarehouse/instances/{instance-id}";
+    private static final String UPDATED_BY_LINK = "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}";
+
+    private final WarehouseS3Credentials.Links credentials1Links = new WarehouseS3Credentials.Links(
+            SELF_LINK, PARENT_LINK, INSTANCE_LINK, UPDATED_BY_LINK
+    );
     private final WarehouseS3Credentials credentials1 = new WarehouseS3Credentials("region", "accessKey",
-             "secretKey", "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
+             "secretKey",
             DateTime.parse("2017-08-02T09:40:24.064Z"), credentials1Links);
     private final WarehouseS3Credentials credentials2 = new WarehouseS3Credentials( "region2", "accessKey2",
-            "secretKey2", null, null, null);
+            "secretKey2", null, null);
 
     private final Map<String, String> links = new HashMap<String, String>() {{
         put("self", "/gdc/datawarehouse/instances/{instance-id}/s3");

--- a/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsTest.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseS3CredentialsTest.java
@@ -6,9 +6,6 @@ package com.gooddata.warehouse;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.gooddata.util.ResourceUtils.readObjectFromResource;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource;
@@ -27,23 +24,21 @@ public class WarehouseS3CredentialsTest {
     private static final String SELF_LINK = "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey";
     private static final String PARENT_LINK = "/gdc/datawarehouse/instances/{instance-id}/s3";
     private static final String INSTANCE_LINK = "/gdc/datawarehouse/instances/{instance-id}";
-    private static final Map<String, String> LINKS = new HashMap<String, String>() {{
-       put("self", SELF_LINK);
-       put("parent", PARENT_LINK);
-       put("instance", INSTANCE_LINK);
-    }};
+    private static final WarehouseS3Credentials.Links LINKS = new WarehouseS3Credentials.Links(
+            SELF_LINK, PARENT_LINK, INSTANCE_LINK, UPDATED_BY
+    );
 
     @Test
     public void serializeFull() {
         final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, SECRET_KEY,
-                UPDATED_BY, UPDATED_AT, LINKS);
+                UPDATED_AT, LINKS);
         assertThat(credentials, jsonEquals(resource("warehouse/s3Credentials-full.json")));
     }
 
     @Test
     public void serializeGet() {
-        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, UPDATED_BY,
-                UPDATED_AT);
+        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, null,
+                UPDATED_AT, null);
         assertThat(credentials, jsonEquals(resource("warehouse/s3Credentials-get.json")));
     }
 
@@ -60,7 +55,6 @@ public class WarehouseS3CredentialsTest {
 
         assertThat(credentials.getRegion(), is(REGION));
         assertThat(credentials.getAccessKey(), is(ACCESS_KEY));
-        assertThat(credentials.getUpdatedBy(), is(UPDATED_BY));
         assertThat(credentials.getSecretKey(), is(SECRET_KEY));
         assertThat(credentials.getUpdated().toString(), is(UPDATED_AT.toString()));
         assertThat(credentials.getLinks(), is(LINKS));
@@ -73,7 +67,6 @@ public class WarehouseS3CredentialsTest {
 
         assertThat(credentials.getRegion(), is(REGION));
         assertThat(credentials.getAccessKey(), is(ACCESS_KEY));
-        assertThat(credentials.getUpdatedBy(), is(UPDATED_BY));
         assertThat(credentials.getSecretKey(), is(nullValue()));
         assertThat(credentials.getUpdated().toString(), is(UPDATED_AT.toString()));
         assertThat(credentials.getLinks(), is(nullValue()));
@@ -87,41 +80,41 @@ public class WarehouseS3CredentialsTest {
         assertThat(credentials.getRegion(), is(REGION));
         assertThat(credentials.getAccessKey(), is(ACCESS_KEY));
         assertThat(credentials.getSecretKey(), is(SECRET_KEY));
-        assertThat(credentials.getUpdatedBy(), is(nullValue()));
         assertThat(credentials.getUpdated(), is(nullValue()));
         assertThat(credentials.getLinks(), is(nullValue()));
     }
 
     @Test
     public void withSecretKey() {
-        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY,
-                UPDATED_BY, UPDATED_AT);
+        final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, null,
+                UPDATED_AT, null);
         assertThat(credentials.getSecretKey(), is(nullValue()));
-        assertThat(credentials.withSecretKey(SECRET_KEY).getSecretKey(), is(SECRET_KEY));
+
+        credentials.setSecretKey(SECRET_KEY);
+        assertThat(credentials.getSecretKey(), is(SECRET_KEY));
     }
 
     @Test
     public void withLinks() {
         final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY,
-                UPDATED_BY, UPDATED_AT).withLinks(LINKS);
+                SECRET_KEY, UPDATED_AT, LINKS);
         assertThat(credentials.getLinks(), is(LINKS));
     }
 
     @Test
     public void withLinksForWarehouse() {
         final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY,
-                "updaterId", UPDATED_AT).withLinks("instanceId");
-        assertThat(credentials.getInstanceUri(), endsWith("/instanceId"));
-        assertThat(credentials.getListUri(), endsWith("/instanceId/s3"));
-        assertThat(credentials.getUri(), is(WarehouseS3Credentials.TEMPLATE
-                .expand("instanceId", REGION, ACCESS_KEY).toString()));
-        assertThat(credentials.getUpdatedByUri(), endsWith("/updaterId"));
+                "updaterId", UPDATED_AT, LINKS);
+        assertThat(credentials.getInstanceUri(), endsWith("/{instance-id}"));
+        assertThat(credentials.getListUri(), endsWith("/{instance-id}/s3"));
+        assertThat(credentials.getUri(), endsWith("/{instance-id}/s3/region/accessKey"));
+        assertThat(credentials.getUpdatedByUri(), endsWith("/users/{user-id}"));
     }
 
     @Test
     public void getUri() {
         final WarehouseS3Credentials credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY,
-                UPDATED_BY, UPDATED_AT).withLinks(LINKS);
+                UPDATED_BY, UPDATED_AT, LINKS);
 
         assertThat(credentials.getUri(), is("/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey"));
     }
@@ -131,6 +124,6 @@ public class WarehouseS3CredentialsTest {
         final WarehouseS3Credentials credentials = readObjectFromResource("/warehouse/s3Credentials-create.json",
                 WarehouseS3Credentials.class);
 
-        assertThat(credentials.toString(), is("WarehouseS3Credentials[region=region,accessKey=accessKey,updated=<null>,updatedBy=<null>]"));
+        assertThat(credentials.toString(), is("WarehouseS3Credentials[region=region,accessKey=accessKey,updated=<null>]"));
     }
 }

--- a/src/test/java/com/gooddata/warehouse/WarehouseServiceAT.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseServiceAT.java
@@ -167,7 +167,8 @@ public class WarehouseServiceAT extends AbstractGoodDataAT {
     @Test(groups = { "warehouse", "isolated_domain" }, dependsOnMethods = "addS3Credentials")
     public void updateS3Credentials() {
         final DateTime lastUpdated = s3Credentials.getUpdated();
-        s3Credentials = service.updateS3Credentials(s3Credentials.withSecretKey("newSecretKey"))
+        s3Credentials.setSecretKey("newSecretKey");
+        s3Credentials = service.updateS3Credentials(s3Credentials)
                 .get(1, TimeUnit.MINUTES);
 
         assertThat(s3Credentials, notNullValue());

--- a/src/test/java/com/gooddata/warehouse/WarehouseServiceIT.java
+++ b/src/test/java/com/gooddata/warehouse/WarehouseServiceIT.java
@@ -7,12 +7,14 @@ package com.gooddata.warehouse;
 
 import com.gooddata.AbstractGoodDataIT;
 import com.gooddata.GoodDataException;
+import com.gooddata.account.Account;
 import com.gooddata.collections.MultiPageList;
 import com.gooddata.collections.PageRequest;
 import com.gooddata.collections.PageableList;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matchers;
+import org.joda.time.DateTime;
 import org.springframework.web.client.RestClientException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -51,14 +53,19 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
     private static final String WAREHOUSE_S3_CREDENTIALS_LIST_URI = WarehouseS3CredentialsList.TEMPLATE.expand(WAREHOUSE_ID).toString();
     private static final String WAREHOUSE_S3_CREDENTIALS_URI = WarehouseS3Credentials.TEMPLATE.expand(WAREHOUSE_ID, REGION, ACCESS_KEY).toString();
     private static final String REMOVE_USER_TASK_DONE = "/warehouse/removeUserTask-finished.json";
+    private static final String UPDATED_BY_URI = Account.TEMPLATE.expand("updatedBy").toString();
 
     private static final String CONNECTION_URL = "CONNECTION_URL";
+    private static final WarehouseS3Credentials.Links LINKS = new WarehouseS3Credentials.Links(
+            WAREHOUSE_S3_CREDENTIALS_URI, WAREHOUSE_S3_CREDENTIALS_LIST_URI, WAREHOUSE_URI, UPDATED_BY_URI
+    );
 
     private WarehouseTask pollingTask;
     private WarehouseTask finishedTask;
     private Warehouse warehouse;
     private WarehouseSchema warehouseSchema;
     private WarehouseS3Credentials s3Credentials;
+    private WarehouseS3Credentials s3CredentialsWithLinks;
 
     @BeforeClass
     public void setUp() throws Exception {
@@ -67,6 +74,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
         warehouse = readObjectFromResource(WAREHOUSE, Warehouse.class);
         warehouseSchema = readObjectFromResource(WAREHOUSE_SCHEMA, WarehouseSchema.class);
         s3Credentials = new WarehouseS3Credentials(REGION, ACCESS_KEY, "secretKey");
+        s3CredentialsWithLinks = new WarehouseS3Credentials(REGION, ACCESS_KEY, "secretKey", DateTime.now(), LINKS);
     }
 
     @Test
@@ -586,7 +594,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .withStatus(200);
 
         final WarehouseS3Credentials updated = gd.getWarehouseService()
-                .updateS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+                .updateS3Credentials(s3CredentialsWithLinks).get();
         assertThat(updated, notNullValue());
         assertThat(updated.getRegion(), is(REGION));
         assertThat(updated.getAccessKey(), is(ACCESS_KEY));
@@ -608,7 +616,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .respond()
                 .withStatus(409);
 
-        gd.getWarehouseService().updateS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+        gd.getWarehouseService().updateS3Credentials(s3CredentialsWithLinks).get();
     }
 
     @Test(expectedExceptions = WarehouseS3CredentialsException.class,
@@ -620,7 +628,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .respond()
                 .withStatus(409);
 
-        gd.getWarehouseService().updateS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+        gd.getWarehouseService().updateS3Credentials(s3CredentialsWithLinks).get();
     }
 
     @Test(expectedExceptions = WarehouseS3CredentialsException.class,
@@ -646,7 +654,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .respond()
                 .withStatus(409);
 
-        gd.getWarehouseService().updateS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+        gd.getWarehouseService().updateS3Credentials(s3CredentialsWithLinks).get();
     }
 
     @Test
@@ -672,7 +680,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .withBody(readFromResource("/warehouse/s3CredentialsList.json"))
                 .withStatus(200);
 
-        gd.getWarehouseService().removeS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+        gd.getWarehouseService().removeS3Credentials(s3CredentialsWithLinks).get();
     }
 
     @Test(expectedExceptions = WarehouseS3CredentialsException.class,
@@ -690,7 +698,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .respond()
                 .withStatus(409);
 
-        gd.getWarehouseService().removeS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+        gd.getWarehouseService().removeS3Credentials(s3CredentialsWithLinks).get();
     }
 
     @Test(expectedExceptions = WarehouseS3CredentialsException.class,
@@ -702,7 +710,7 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .respond()
                 .withStatus(409);
 
-        gd.getWarehouseService().removeS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+        gd.getWarehouseService().removeS3Credentials(s3CredentialsWithLinks).get();
     }
 
     @Test(expectedExceptions = WarehouseS3CredentialsException.class,
@@ -728,6 +736,6 @@ public class WarehouseServiceIT extends AbstractGoodDataIT {
                 .respond()
                 .withStatus(409);
 
-        gd.getWarehouseService().removeS3Credentials(s3Credentials.withLinks(warehouse.getId())).get();
+        gd.getWarehouseService().removeS3Credentials(s3CredentialsWithLinks).get();
     }
 }

--- a/src/test/resources/warehouse/s3Credentials-full.json
+++ b/src/test/resources/warehouse/s3Credentials-full.json
@@ -3,12 +3,12 @@
     "region": "region",
     "accessKey": "accessKey",
     "secretKey": "secretKey",
-    "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
     "updated": "2017-08-02T09:40:24.064Z",
     "links": {
       "self": "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey",
       "parent": "/gdc/datawarehouse/instances/{instance-id}/s3",
-      "instance": "/gdc/datawarehouse/instances/{instance-id}"
+      "instance": "/gdc/datawarehouse/instances/{instance-id}",
+      "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}"
     }
   }
 }

--- a/src/test/resources/warehouse/s3Credentials-get.json
+++ b/src/test/resources/warehouse/s3Credentials-get.json
@@ -2,7 +2,6 @@
   "s3Credentials": {
     "region": "region",
     "accessKey": "accessKey",
-    "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
     "updated": "2017-08-02T09:40:24.064Z"
   }
 }

--- a/src/test/resources/warehouse/s3CredentialsList.json
+++ b/src/test/resources/warehouse/s3CredentialsList.json
@@ -6,12 +6,12 @@
           "region": "region",
           "accessKey": "accessKey",
           "secretKey": "secretKey",
-          "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}",
           "updated": "2017-08-02T09:40:24.064Z",
           "links": {
             "self": "/gdc/datawarehouse/instances/{instance-id}/s3/region/accessKey",
             "parent": "/gdc/datawarehouse/instances/{instance-id}/s3",
-            "instance": "/gdc/datawarehouse/instances/{instance-id}"
+            "instance": "/gdc/datawarehouse/instances/{instance-id}",
+            "updatedBy": "/gdc/datawarehouse/instances/{instance-id}/users/{user-id}"
           }
         }
       },


### PR DESCRIPTION
#This PR gets rid of `updatedBy` field from S3 DTO and its JSON, and leaves only `links.updatedBy` (the URI to updater's profile). Closes #495 

`updatedBy` field of `WarehouseS3Credentials` was for internal use only and should not be accessed by the users of the SDK. Therefore it is now being removed. The users of SDK should use `getUpdatedByUri()` instead.

`withLinks` methods are also being removed, as well as public constructor which was marked as not intended for end users