### PR TITLE
Use URI because it is not double-encoded by RestTemplate

### DIFF
--- a/src/main/java/com/gooddata/AbstractPollHandler.java
+++ b/src/main/java/com/gooddata/AbstractPollHandler.java
@@ -7,6 +7,8 @@ package com.gooddata;
 
 import org.springframework.http.client.ClientHttpResponse;
 
+import java.net.URI;
+
 import static com.gooddata.util.Validate.notNull;
 
 /**
@@ -21,7 +23,7 @@ import static com.gooddata.util.Validate.notNull;
  */
 public abstract class AbstractPollHandler<P,R> extends AbstractPollHandlerBase<P,R> {
 
-    private String pollingUri;
+    private URI pollingUri;
 
     /**
      * Creates a new instance of polling handler
@@ -31,15 +33,20 @@ public abstract class AbstractPollHandler<P,R> extends AbstractPollHandlerBase<P
      */
     public AbstractPollHandler(final String pollingUri, final Class<P> pollClass, Class<R> resultClass) {
         super(pollClass, resultClass);
-        this.pollingUri = notNull(pollingUri, "pollingUri");
+        setPollingUri(pollingUri);
     }
 
     @Override
     public final String getPollingUri() {
+        return pollingUri.toString();
+    }
+
+    @Override
+    public final URI getPolling() {
         return pollingUri;
     }
 
     protected void setPollingUri(final String pollingUri) {
-        this.pollingUri = pollingUri;
+        this.pollingUri = URI.create(notNull(pollingUri, "pollingUri"));
     }
 }

--- a/src/main/java/com/gooddata/AbstractService.java
+++ b/src/main/java/com/gooddata/AbstractService.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -71,7 +72,7 @@ public abstract class AbstractService {
         notNull(handler, "handler");
         final ClientHttpResponse response;
         try {
-            response = restTemplate.execute(handler.getPollingUri(), GET, null, reusableResponseExtractor);
+            response = restTemplate.execute(handler.getPolling(), GET, null, reusableResponseExtractor);
         } catch (GoodDataRestException e) {
             handler.handlePollException(e);
             throw new GoodDataException("Handler " + handler.getClass().getName() + " didn't handle exception", e);

--- a/src/main/java/com/gooddata/PollHandler.java
+++ b/src/main/java/com/gooddata/PollHandler.java
@@ -8,6 +8,7 @@ package com.gooddata;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.IOException;
+import java.net.URI;
 
 /**
  * For internal use by services employing polling.<p>
@@ -24,6 +25,15 @@ public interface PollHandler<P,R> {
      * @return URI string
      */
     String getPollingUri();
+
+    /**
+     * Get URI used for polling.
+     *
+     * @return URI string
+     */
+    default URI getPolling() {
+        return URI.create(getPollingUri());
+    }
 
     /**
      * Get class of result after polling.

--- a/src/test/java/com/gooddata/AbstractServiceTest.java
+++ b/src/test/java/com/gooddata/AbstractServiceTest.java
@@ -36,7 +36,7 @@ public class AbstractServiceTest {
         service = new AbstractService(restTemplate) {};
         final ClientHttpResponse response = mock(ClientHttpResponse.class);
         when(response.getStatusCode()).thenReturn(HttpStatus.OK);
-        when(restTemplate.execute(anyString(), any(HttpMethod.class), any(RequestCallback.class), any(ResponseExtractor.class)))
+        when(restTemplate.execute(any(), any(HttpMethod.class), any(RequestCallback.class), any(ResponseExtractor.class)))
                 .thenReturn(response);
     }
 

--- a/src/test/java/com/gooddata/PollHandlerIT.java
+++ b/src/test/java/com/gooddata/PollHandlerIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata;
+
+import org.springframework.web.client.RestTemplate;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static net.jadler.Jadler.onRequest;
+
+public class PollHandlerIT extends AbstractGoodDataIT {
+
+    private static final String PATH = "/foo";
+    private static final String PARAM = "q";
+    private static final String VALUE = "eAEdizEOgCAQBL9CtraBwsLOR1gZC5QzuUROA2csiH8X7DYzswXKehAGTPKvYBJdZ1ITaGdh5VPQ%0AIZIm3jKGuUB8bP34%2BERCOVfNoQLbO%2BvwLh281nq9ldpheT%2FgtSHo%0A";
+    private static final String URI = PATH + "?" + PARAM + "=" + VALUE;
+
+    private PollingService service;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        service = new PollingService(gd.getRestTemplate());
+
+        onRequest()
+                .havingMethodEqualTo("GET")
+                .havingPathEqualTo(PATH)
+                .havingParameterEqualTo(PARAM, VALUE)
+            .respond()
+                .withStatus(200)
+        ;
+    }
+
+    @Test
+    public void shouldPollOnEncodedUri() throws Exception {
+        service.test(URI).get();
+    }
+
+    private static class PollingService extends AbstractService {
+
+        PollingService(final RestTemplate restTemplate) {
+            super(restTemplate);
+        }
+
+        FutureResult<Void> test(final String uri) {
+            return new PollResult<>(this, new SimplePollHandler<Void>(uri, Void.class) {
+                @Override
+                public void handlePollException(final GoodDataRestException e) {
+                    throw e;
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceTest.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceTest.java
@@ -253,7 +253,7 @@ public class ProcessServiceTest {
         when(restTemplate.postForObject(eq(SCHEDULE_EXECUTIONS_URI), any(ScheduleExecution.class), eq(ScheduleExecution.class)))
                 .thenReturn(execution);
 
-        when(restTemplate.execute(eq(SCHEDULE_EXECUTION_URI), eq(GET), any(), any()))
+        when(restTemplate.execute(eq(URI.create(SCHEDULE_EXECUTION_URI)), eq(GET), any(), any()))
                 .thenThrow(mock(GoodDataRestException.class));
 
         FutureResult<ScheduleExecution> futureResult = processService.executeSchedule(schedule);


### PR DESCRIPTION
Close #498