### PR TITLE
add equals and hashcode because parent class has them

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>com.gooddata</groupId>
             <artifactId>gooddata-rest-common</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.gooddata</groupId>
@@ -330,6 +330,12 @@
             <groupId>com.shazam</groupId>
             <artifactId>shazamcrest</artifactId>
             <version>0.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>2.3.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/gooddata/auditevent/AuditEventPageRequest.java
+++ b/src/main/java/com/gooddata/auditevent/AuditEventPageRequest.java
@@ -17,7 +17,7 @@ import static org.apache.commons.lang3.Validate.notNull;
 /**
  * Class to encapsulate time filtering and paging parameters
  */
-public class AuditEventPageRequest extends PageRequest {
+public final class AuditEventPageRequest extends PageRequest {
 
     private DateTime from;
 
@@ -104,6 +104,34 @@ public class AuditEventPageRequest extends PageRequest {
         }
 
         return builderWithPaging;
+    }
+
+    @Override
+    protected boolean canEqual(final Object o) {
+        return o instanceof AuditEventPageRequest;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AuditEventPageRequest)) return false;
+        if (!super.equals(o)) return false;
+
+        final AuditEventPageRequest that = (AuditEventPageRequest) o;
+        if (!that.canEqual(this)) return false;
+
+        if (from != null ? !from.equals(that.from) : that.from != null) return false;
+        if (to != null ? !to.equals(that.to) : that.to != null) return false;
+        return type != null ? type.equals(that.type) : that.type == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (from != null ? from.hashCode() : 0);
+        result = 31 * result + (to != null ? to.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/src/test/java/com/gooddata/auditevent/AuditEventPageRequestTest.java
+++ b/src/test/java/com/gooddata/auditevent/AuditEventPageRequestTest.java
@@ -5,6 +5,8 @@
  */
 package com.gooddata.auditevent;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -96,5 +98,13 @@ public class AuditEventPageRequestTest {
 
         assertThat(result.build().toUriString(), is("?limit=" + DEFAULT_LIMIT +
                 "&from=" + FROM.toDateTime(DateTimeZone.UTC) + "&to=" + TO.toDateTime(DateTimeZone.UTC)));
+    }
+
+    @Test
+    public void shouldVerifyEquals() throws Exception {
+        EqualsVerifier.forClass(AuditEventPageRequest.class)
+                .withRedefinedSuperclass()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
     }
 }


### PR DESCRIPTION
Without equals and hashcode overridden really unexpected things happen when comparing or mocking such classes