### PR TITLE
Add support for metadata bulk get

### DIFF
--- a/src/main/java/com/gooddata/md/BulkGet.java
+++ b/src/main/java/com/gooddata/md/BulkGet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.md;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.gooddata.util.GoodDataToStringBuilder;
+
+import java.util.Collection;
+
+/**
+ * Metadata bulk get result
+ */
+@JsonTypeName("objects")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class BulkGet {
+
+    public static final String URI = "/gdc/md/{projectId}/objects/get";
+
+    private final Collection<Obj> items;
+
+    @JsonCreator
+    BulkGet(@JsonProperty("items") Collection<Obj> items) {
+        this.items = items;
+    }
+
+    public Collection<Obj> getItems() {
+        return items;
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+}

--- a/src/main/java/com/gooddata/md/BulkGetUris.java
+++ b/src/main/java/com/gooddata/md/BulkGetUris.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2004-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.md;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.gooddata.util.GoodDataToStringBuilder;
+
+import java.util.Collection;
+
+import static com.gooddata.util.Validate.notNull;
+
+/**
+ * Metadata bulk get request body representation.
+ * Serialization only.
+ */
+@JsonTypeName("get")
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+class BulkGetUris {
+
+    private final Collection<String> items;
+
+    BulkGetUris(Collection<String> items) {
+        notNull(items, "items");
+        this.items = items;
+    }
+
+    @JsonProperty("items")
+    public Collection<String> getItems() {
+        return items;
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BulkGetUris that = (BulkGetUris) o;
+
+        if (!items.equals(that.items)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return items.hashCode();
+    }
+}

--- a/src/main/java/com/gooddata/md/Obj.java
+++ b/src/main/java/com/gooddata/md/Obj.java
@@ -5,11 +5,32 @@
  */
 package com.gooddata.md;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.gooddata.md.report.Report;
+import com.gooddata.md.report.ReportDefinition;
 import org.springframework.web.util.UriTemplate;
 
 /**
  * First class metadata object - only dto objects, which have URI pointing to themselves should implement this.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonSubTypes({
+        @JsonSubTypes.Type(Attribute.class),
+        @JsonSubTypes.Type(AttributeDisplayForm.class),
+        @JsonSubTypes.Type(Column.class),
+        @JsonSubTypes.Type(DataLoadingColumn.class),
+        @JsonSubTypes.Type(Dataset.class),
+        @JsonSubTypes.Type(Dimension.class),
+        @JsonSubTypes.Type(Fact.class),
+        @JsonSubTypes.Type(Metric.class),
+        @JsonSubTypes.Type(ProjectDashboard.class),
+        @JsonSubTypes.Type(Report.class),
+        @JsonSubTypes.Type(ReportDefinition.class),
+        @JsonSubTypes.Type(ScheduledMail.class),
+        @JsonSubTypes.Type(Table.class),
+        @JsonSubTypes.Type(TableDataLoad.class),
+})
 public interface Obj {
 
     String URI = "/gdc/md/{projectId}/obj";

--- a/src/test/java/com/gooddata/md/MetadataServiceAT.java
+++ b/src/test/java/com/gooddata/md/MetadataServiceAT.java
@@ -5,15 +5,6 @@
  */
 package com.gooddata.md;
 
-import static com.gooddata.export.ExportFormat.PDF;
-import static com.gooddata.export.ExportFormat.XLS;
-import static com.gooddata.md.Restriction.identifier;
-import static com.gooddata.md.report.MetricGroup.METRIC_GROUP;
-import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.testng.AssertJUnit.assertTrue;
-
 import com.gooddata.AbstractGoodDataAT;
 import com.gooddata.md.ProjectDashboard.Tab;
 import com.gooddata.md.report.AttributeInGrid;
@@ -32,6 +23,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.gooddata.export.ExportFormat.PDF;
+import static com.gooddata.export.ExportFormat.XLS;
+import static com.gooddata.md.Restriction.identifier;
+import static com.gooddata.md.report.MetricGroup.METRIC_GROUP;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Metadata acceptance tests.
@@ -123,6 +127,21 @@ public class MetadataServiceAT extends AbstractGoodDataAT {
         final Usage usage2 = usageIterator.next();
         assertTrue(uris.containsValue(usage2.getUri()));
         assertThat(usage2.getUsedBy(), hasSize(5));
+    }
+
+    @Test(groups = "md", dependsOnGroups = "model")
+    public void getObjsByUris() throws Exception {
+        final MetadataService md = gd.getMetadataService();
+
+        final Map<String, String> uris =
+                md.identifiersToUris(project, asList(
+                        "attr.person.department",
+                        "attr.person.role",
+                        "fact.person.shoesize"
+                ));
+
+        final Collection<Obj> objects = md.getObjsByUris(project, uris.values());
+        assertThat(objects.stream().map(Obj::getUri).collect(Collectors.toSet()), is(new HashSet<>(uris.values())));
     }
 
     @Test(groups = "md", dependsOnMethods = "createReport")

--- a/src/test/java/com/gooddata/md/MetadataServiceTest.java
+++ b/src/test/java/com/gooddata/md/MetadataServiceTest.java
@@ -131,6 +131,45 @@ public class MetadataServiceTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testGetObjsByUrisNullProject() throws Exception {
+        service.getObjsByUris(null, Collections.emptyList());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testGetObjsByUrisNullUris() throws Exception {
+        service.getObjsByUris(project, null);
+    }
+
+    @Test
+    public void testGetObjsByUris() throws Exception {
+        final BulkGetUris request = new BulkGetUris(Collections.singletonList(URI));
+        final BulkGet response = new BulkGet(Collections.singletonList(mock(Obj.class)));
+        when(restTemplate.postForObject(BulkGet.URI, request, BulkGet.class, PROJECT_ID)).thenReturn(response);
+
+        final Collection<Obj> result = service.getObjsByUris(project, request.getItems());
+        assertThat(result, is(response.getItems()));
+    }
+
+    @Test(expectedExceptions = GoodDataException.class)
+    public void testGetObjsByUrisWithClientSideHTTPError() throws Exception {
+        final BulkGetUris request = new BulkGetUris(Collections.singletonList(""));
+        when(restTemplate.postForObject(BulkGet.URI, request, BulkGet.class, PROJECT_ID)).thenThrow(new RestClientException(""));
+        service.getObjsByUris(project, request.getItems());
+    }
+
+    @Test(expectedExceptions = GoodDataRestException.class)
+    public void testGetObjsByUrisWithServerSideHTTPError() throws Exception {
+        final BulkGetUris request = new BulkGetUris(Collections.singletonList(""));
+        when(restTemplate.postForObject(BulkGet.URI, request, BulkGet.class, PROJECT_ID)).thenThrow(new GoodDataRestException(500, "", "", "", ""));
+        service.getObjsByUris(project, request.getItems());
+    }
+
+    @Test(expectedExceptions = GoodDataException.class)
+    public void testGetObjsByUrisWithNoResponseFromAPI() throws Exception {
+        service.getObjsByUris(project, Collections.emptyList());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testGetObjByUriNullUri() throws Exception {
         service.getObjByUri(null, Obj.class);
     }

--- a/src/test/resources/md/bulk-get.json
+++ b/src/test/resources/md/bulk-get.json
@@ -1,0 +1,90 @@
+{
+  "objects": {
+    "items": [
+      {
+        "dataSet": {
+          "content": {
+            "ties": [
+              "/gdc/md/PROJECT_ID/obj/688400"
+            ],
+            "mode": "",
+            "facts": [
+              "/gdc/md/PROJECT_ID/obj/688401",
+              "/gdc/md/PROJECT_ID/obj/688402"
+            ],
+            "dataLoadingColumns": [],
+            "attributes": [
+              "/gdc/md/PROJECT_ID/obj/688399",
+              "/gdc/md/PROJECT_ID/obj/688411",
+              "/gdc/md/PROJECT_ID/obj/688425"
+            ]
+          },
+          "links": {
+            "dataUploads": "/gdc/md/PROJECT_ID/data/uploads/688536"
+          },
+          "meta": {
+            "author": "/gdc/account/profile/PROFILE_ID",
+            "uri": "/gdc/md/PROJECT_ID/obj/DATASET_ID",
+            "tags": "",
+            "created": "2015-01-28 17:35:47",
+            "identifier": "DATASET_ID.dataset.dt",
+            "deprecated": "0",
+            "summary": "DataSet Date",
+            "title": "Date (Org minDate-first deal)",
+            "category": "dataSet",
+            "updated": "2015-01-28 17:35:47",
+            "contributor": "/gdc/account/profile/PROFILE_ID"
+          }
+        }
+      }, {
+        "fact" : {
+          "content" : {
+            "expr" : [
+              {
+                "data" : "/gdc/md/PROJECT_ID/obj/COL_ID",
+                "type" : "col"
+              }
+            ],
+            "folders" : [
+              "/gdc/md/PROJECT_ID/obj/FOLDER_ID",
+              "/gdc/md/PROJECT_ID/obj/FOLDER_ID2"
+            ]
+          },
+          "meta" : {
+            "author" : "/gdc/account/profile/AUTHOR_ID",
+            "uri" : "/gdc/md/PROJECT_ID/obj/FACT_ID",
+            "tags" : "",
+            "created" : "2014-04-11 13:45:53",
+            "identifier" : "fact.person.shoesize",
+            "deprecated" : "0",
+            "summary" : "",
+            "title" : "Person Shoe Size",
+            "category" : "fact",
+            "updated" : "2014-04-11 13:46:52",
+            "contributor" : "/gdc/account/profile/CONTRIBUTOR_ID"
+          }
+        }
+      }, {
+        "metric" : {
+          "content" : {
+            "expression" : "[/gdc/md/PROJECT_ID/obj/EXPR_ID]",
+            "format" : "FORMAT"
+          },
+          "meta" : {
+            "author" : "/gdc/account/profile/USER_ID",
+            "uri" : "/gdc/md/PROJECT_ID/obj/METRIC_ID",
+            "tags" : "",
+            "created" : "2014-04-11 13:45:56",
+            "identifier" : "attr.person.id.name",
+            "deprecated" : "0",
+            "summary" : "",
+            "title" : "Person Name",
+            "category" : "attributeDisplayForm",
+            "updated" : "2014-04-11 13:45:56",
+            "contributor" : "/gdc/account/profile/USER_ID"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Metadata API supports bulk retrieval of objects by their URIs. The SDK
did not support this, so one had to retrieve objects one by one. Now,
with the getObjsByUris() methods it is possible to retrieve multiple
objects using a single request.