### PR TITLE
Fix link to Date::Manip::Recur documentation

### DIFF
--- a/src/main/java/com/gooddata/md/ScheduledMailWhen.java
+++ b/src/main/java/com/gooddata/md/ScheduledMailWhen.java
@@ -22,7 +22,7 @@ public class ScheduledMailWhen {
 
     /**
      * Cron like recurrency pattern. Example: "0:0:0:1*12:0:0".
-     * For details, please see <a href="http://search.cpan.org/~sbeck/Date-Manip-6.49/lib/Date/Manip/Recur.pod">this comprehensive documentation</a>.
+     * For details, please see <a href="http://search.cpan.org/~sbeck/Date-Manip-6.60/lib/Date/Manip/Recur.pod">this comprehensive documentation</a>.
      */
     private String recurrency;
     private LocalDate startDate;


### PR DESCRIPTION
Old links is no longer valid as old version of the library was probably removed from the CPAN.