### PR TITLE
fix: remove redundant name in executeafm dtos

### DIFF
--- a/src/main/java/com/gooddata/executeafm/response/ResultDimension.java
+++ b/src/main/java/com/gooddata/executeafm/response/ResultDimension.java
@@ -19,34 +19,23 @@ import static java.util.Arrays.asList;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResultDimension {
-    private final String name;
     private final List<Header> headers;
 
     /**
-     * Creates the result dimension of given name and headers
-     * @param name name
+     * Creates the result dimension of given headers
      * @param headers headers
      */
     @JsonCreator
-    public ResultDimension(@JsonProperty("name") final String name, @JsonProperty("headers") final List<Header> headers) {
-        this.name = name;
+    public ResultDimension(@JsonProperty("headers") final List<Header> headers) {
         this.headers = headers;
     }
 
     /**
-     * Creates the result dimension of given name and headers
-     * @param name name
+     * Creates the result dimension of given headers
      * @param headers headers
      */
-    public ResultDimension(final String name, final Header... headers) {
-        this(name, asList(headers));
-    }
-
-    /**
-     * @return dimension name, human readable (must not be unique, can contain spaces, special chars, etc.)
-     */
-    public String getName() {
-        return name;
+    public ResultDimension(final Header... headers) {
+        this(asList(headers));
     }
 
     /**

--- a/src/main/java/com/gooddata/executeafm/resultspec/Dimension.java
+++ b/src/main/java/com/gooddata/executeafm/resultspec/Dimension.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.gooddata.util.Validate.notEmpty;
 import static com.gooddata.util.Validate.notNull;
 import static java.util.Arrays.asList;
 
@@ -33,37 +32,36 @@ public class Dimension {
      */
     public static final String MEASURE_GROUP = "measureGroup";
 
-    private final String name;
     private final List<String> itemIdentifiers;
     private Set<TotalItem> totals;
 
     /**
      * Creates new instance
-     * @param name dimension name
      * @param itemIdentifiers identifiers referencing attributes from {@link Afm} or {@link Dimension#MEASURE_GROUP}
      * @param totals set of totals
      */
     @JsonCreator
     public Dimension(
-            @JsonProperty("name") final String name,
             @JsonProperty("itemIdentifiers") final List<String> itemIdentifiers,
             @JsonProperty("totals") final Set<TotalItem> totals) {
-        this.name = notEmpty(name, "name");
         this.itemIdentifiers = itemIdentifiers;
         this.totals = totals;
     }
 
     /**
      * Creates new instance
-     * @param name dimension name
      * @param itemIdentifiers identifiers referencing attributes from {@link Afm} or {@link Dimension#MEASURE_GROUP}
      */
-    public Dimension(final String name, final String... itemIdentifiers) {
-        this(name, asList(itemIdentifiers), null);
+    public Dimension(final List<String> itemIdentifiers) {
+        this.itemIdentifiers = itemIdentifiers;
     }
 
-    public String getName() {
-        return name;
+    /**
+     * Creates new instance
+     * @param itemIdentifiers identifiers referencing attributes from {@link Afm} or {@link Dimension#MEASURE_GROUP}
+     */
+    public Dimension(final String... itemIdentifiers) {
+        this(asList(itemIdentifiers));
     }
 
     public List<String> getItemIdentifiers() {

--- a/src/test/groovy/com/gooddata/executeafm/ExecutionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/ExecutionTest.groovy
@@ -44,7 +44,7 @@ class ExecutionTest extends Specification {
                         [new NativeTotalItem('mId', 'a1', 'a2')]
                 ),
                 new ResultSpec(
-                        [new Dimension('dName', ['i1'], [new TotalItem('mId', Total.AVG, 'a1')] as Set)],
+                        [new Dimension(['i1'], [new TotalItem('mId', Total.AVG, 'a1')] as Set)],
                         [
                                 new AttributeSortItem(Direction.ASC, 'aId'),
                                 new MeasureSortItem(Direction.ASC,

--- a/src/test/groovy/com/gooddata/executeafm/response/ExecutionResponseTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/response/ExecutionResponseTest.groovy
@@ -20,7 +20,7 @@ class ExecutionResponseTest extends Specification {
         expect:
         that new ExecutionResponse(
                 [
-                        new ResultDimension('x',
+                        new ResultDimension(
                                 new AttributeHeader('Account', 'account', '/gdc/md/FoodMartDemo/obj/124', 'attr.account'),
                                 new AttributeHeader('Account Type', 'accountType', '/gdc/md/FoodMartDemo/obj/113', 'attr.accountType'),
                                 new MeasureGroupHeader([
@@ -40,7 +40,6 @@ class ExecutionResponseTest extends Specification {
         response.executionResultUri == 'poll'
 
         response.dimensions.size() == 1
-        response.dimensions[0].name == 'x'
         response.dimensions[0].headers.size() == 3
 
         AttributeHeader account = response.dimensions[0].headers[0] as AttributeHeader

--- a/src/test/groovy/com/gooddata/executeafm/response/ResultDimensionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/response/ResultDimensionTest.groovy
@@ -19,7 +19,7 @@ class ResultDimensionTest extends Specification {
 
     def "should serialize"() {
         expect:
-        that new ResultDimension('dName',
+        that new ResultDimension(
                 new AttributeHeader('Name', 'a1', '/gdc/md/project_id/obj/123', 'attr.dataset.name'),
                 new MeasureGroupHeader([new MeasureHeaderItem('Name', '#,##0.00', 'm1')])),
                 jsonEquals(resource(RESULT_DIMENSION_JSON))
@@ -30,7 +30,6 @@ class ResultDimensionTest extends Specification {
         ResultDimension dimension = readObjectFromResource("/$RESULT_DIMENSION_JSON", ResultDimension)
 
         then:
-        dimension.name == 'dName'
         dimension.headers.size() == 2
         dimension.headers[0].localIdentifier == 'a1'
         dimension.headers[1].items.first().localIdentifier == 'm1'

--- a/src/test/groovy/com/gooddata/executeafm/resultspec/DimensionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/resultspec/DimensionTest.groovy
@@ -22,13 +22,13 @@ class DimensionTest extends Specification {
 
     def "should serialize"() {
         expect:
-        that new Dimension('dName', 'i1', 'i2'),
+        that new Dimension('i1', 'i2'),
                 jsonEquals(resource(DIMENSION_JSON))
     }
 
     def "should serialize full"() {
         expect:
-        that new Dimension('dName', 'i1', 'i2')
+        that new Dimension('i1', 'i2')
                 .addTotal(TOTAL),
                     jsonEquals(resource(DIMENSION_FULL_JSON))
     }
@@ -38,7 +38,6 @@ class DimensionTest extends Specification {
         Dimension dimension = readObjectFromResource("/$DIMENSION_JSON", Dimension)
 
         then:
-        dimension.name == 'dName'
         dimension.itemIdentifiers == ['i1', 'i2']
         dimension.totals == null
     }
@@ -48,7 +47,6 @@ class DimensionTest extends Specification {
         Dimension dimension = readObjectFromResource("/$DIMENSION_FULL_JSON", Dimension)
 
         then:
-        dimension.name == 'dName'
         dimension.itemIdentifiers == ['i1', 'i2']
         dimension.totals.size() == 1
         dimension.totals.first() == TOTAL
@@ -57,7 +55,7 @@ class DimensionTest extends Specification {
 
     def "should add and find total"() {
         given:
-        Dimension dimension = new Dimension('d1', 'i1', 'i2')
+        Dimension dimension = new Dimension('i1', 'i2')
 
         when:
         dimension.addTotal(TOTAL)

--- a/src/test/groovy/com/gooddata/executeafm/resultspec/ResultSpecTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/resultspec/ResultSpecTest.groovy
@@ -20,7 +20,7 @@ class ResultSpecTest extends Specification {
     def "should serialize full"() {
         expect:
         that new ResultSpec(
-                [new Dimension('dName', 'i1')],
+                [new Dimension('i1')],
                 [
                         new AttributeSortItem(Direction.ASC, 'aId'),
                         new MeasureSortItem(Direction.ASC,
@@ -53,7 +53,6 @@ class ResultSpecTest extends Specification {
 
         then:
         with(resultSpec) {
-            dimensions[0].name == 'dName'
             dimensions[0].itemIdentifiers == ['i1']
         }
 
@@ -77,12 +76,11 @@ class ResultSpecTest extends Specification {
     def "should add items"() {
         when:
         def resultSpec = new ResultSpec()
-            .addDimension(new Dimension('dName'))
+            .addDimension(new Dimension([]))
             .addSort(new MeasureSortItem(Direction.ASC))
 
         then:
         with(resultSpec) {
-            dimensions.first().name == 'dName'
             sorts.size() == 1
         }
     }

--- a/src/test/resources/executeafm/executionFull.json
+++ b/src/test/resources/executeafm/executionFull.json
@@ -41,7 +41,6 @@
     "resultSpec": {
       "dimensions": [
         {
-          "name": "dName",
           "itemIdentifiers": [
             "i1"
           ],

--- a/src/test/resources/executeafm/response/executionResponse.json
+++ b/src/test/resources/executeafm/response/executionResponse.json
@@ -5,7 +5,6 @@
     },
     "dimensions": [
       {
-        "name": "x",
         "headers": [
           {
             "attributeHeader": {

--- a/src/test/resources/executeafm/response/resultDimension.json
+++ b/src/test/resources/executeafm/response/resultDimension.json
@@ -1,5 +1,4 @@
 {
-  "name": "dName",
   "headers": [
     {
       "attributeHeader": {

--- a/src/test/resources/executeafm/resultspec/dimension.json
+++ b/src/test/resources/executeafm/resultspec/dimension.json
@@ -1,5 +1,4 @@
 {
-  "name": "dName",
   "itemIdentifiers": [
     "i1",
     "i2"

--- a/src/test/resources/executeafm/resultspec/dimensionFull.json
+++ b/src/test/resources/executeafm/resultspec/dimensionFull.json
@@ -1,5 +1,4 @@
 {
-  "name": "dName",
   "itemIdentifiers": [
     "i1",
     "i2"

--- a/src/test/resources/executeafm/resultspec/resultSpec.json
+++ b/src/test/resources/executeafm/resultspec/resultSpec.json
@@ -1,7 +1,6 @@
 {
   "dimensions": [
     {
-      "name": "dName",
       "itemIdentifiers": [
         "i1"
       ]


### PR DESCRIPTION
This is backward incompatible, however, there is no service yet using it.
Resolves #545