### PR TITLE
Introduce AttributeHeader.formOf

### DIFF
--- a/src/main/java/com/gooddata/executeafm/response/AttributeHeader.java
+++ b/src/main/java/com/gooddata/executeafm/response/AttributeHeader.java
@@ -29,21 +29,26 @@ public class AttributeHeader implements Header, LocallyIdentifiable {
     private final String localIdentifier;
     private final String uri;
     private final String identifier;
+    private final AttributeInHeader formOf;
 
     private List<TotalHeaderItem> totalItems;
 
     /**
      * Creates new header
+     * @deprecated use the constructor with {@link AttributeInHeader}
+     *
      * @param name name
      * @param localIdentifier local identifier
      * @param uri uri
      * @param identifier identifier
      */
+    @Deprecated
     public AttributeHeader(final String name, final String localIdentifier, final String uri, final String identifier) {
-        this.name = name;
-        this.localIdentifier = localIdentifier;
-        this.uri = uri;
-        this.identifier = identifier;
+        this.name = notEmpty(name, "name");
+        this.localIdentifier = notEmpty(localIdentifier, "localIdentifier");
+        this.uri = notEmpty(uri, "uri");
+        this.identifier = notEmpty(identifier, "identifier");
+        this.formOf = null;
     }
 
     /**
@@ -52,6 +57,19 @@ public class AttributeHeader implements Header, LocallyIdentifiable {
      * @param localIdentifier local identifier
      * @param uri uri
      * @param identifier identifier
+     * @param formOf info about attribute which this header's display form is form of
+     */
+    public AttributeHeader(final String name, final String localIdentifier, final String uri, final String identifier, final AttributeInHeader formOf) {
+        this(name, localIdentifier, uri, identifier, formOf, null);
+    }
+
+    /**
+     * Creates new header
+     * @param name name
+     * @param localIdentifier local identifier
+     * @param uri uri
+     * @param identifier identifier
+     * @param formOf info about attribute which this header's display form is form of
      * @param totalHeaderItems total header items
      */
     @JsonCreator
@@ -59,11 +77,13 @@ public class AttributeHeader implements Header, LocallyIdentifiable {
                            @JsonProperty("localIdentifier") final String localIdentifier,
                            @JsonProperty("uri") final String uri,
                            @JsonProperty("identifier") final String identifier,
+                           @JsonProperty("formOf") final AttributeInHeader formOf,
                            @JsonProperty("totalItems") final List<TotalHeaderItem> totalHeaderItems) {
         this.name = notEmpty(name, "name");
         this.localIdentifier = notEmpty(localIdentifier, "localIdentifier");
         this.uri = notEmpty(uri, "uri");
         this.identifier = notEmpty(identifier, "identifier");
+        this.formOf = notNull(formOf, "formOf");
         this.totalItems = totalHeaderItems;
     }
 
@@ -99,6 +119,10 @@ public class AttributeHeader implements Header, LocallyIdentifiable {
      */
     public String getIdentifier() {
         return identifier;
+    }
+
+    public AttributeInHeader getFormOf() {
+        return formOf;
     }
 
     /**

--- a/src/main/java/com/gooddata/executeafm/response/AttributeInHeader.java
+++ b/src/main/java/com/gooddata/executeafm/response/AttributeInHeader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gooddata.util.GoodDataToStringBuilder;
+
+import static com.gooddata.util.Validate.notEmpty;
+
+/**
+ * Represents attribute in {@link AttributeHeader}
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AttributeInHeader {
+    private final String name;
+    private final String uri;
+    private final String identifier;
+
+    /**
+     * Creates new instance
+     * @param name attribute's title
+     * @param uri attribute's uri
+     * @param identifier attribute's identifier
+     */
+    @JsonCreator
+    public AttributeInHeader(@JsonProperty("name") final String name,
+                             @JsonProperty("uri") final String uri,
+                             @JsonProperty("identifier") final String identifier) {
+        this.name = notEmpty(name, "name");
+        this.uri = notEmpty(uri, "uri");
+        this.identifier = notEmpty(identifier, "identifier");
+    }
+
+    /**
+     * @return attribute's title
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return attribute's uri
+     */
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * @return attribute's identifier
+     */
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AttributeInHeader attributeInHeader = (AttributeInHeader) o;
+
+        if (name != null ? !name.equals(attributeInHeader.name) : attributeInHeader.name != null) return false;
+        if (uri != null ? !uri.equals(attributeInHeader.uri) : attributeInHeader.uri != null) return false;
+        return identifier != null ? identifier.equals(attributeInHeader.identifier) : attributeInHeader.identifier == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (uri != null ? uri.hashCode() : 0);
+        result = 31 * result + (identifier != null ? identifier.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+}

--- a/src/test/groovy/com/gooddata/executeafm/response/AttributeHeaderTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/response/AttributeHeaderTest.groovy
@@ -17,15 +17,17 @@ class AttributeHeaderTest extends Specification {
     private static final String ATTRIBUTE_HEADER_JSON = 'executeafm/response/attributeHeader.json'
     private static final String ATTRIBUTE_HEADER_FULL_JSON = 'executeafm/response/attributeHeaderFull.json'
 
+    private static final AttributeInHeader FORM_OF = new AttributeInHeader('Some attr', '/gdc/md/project_id/obj/567', 'attr.some.id')
+
     def "should serialize full"() {
         expect:
-        that new AttributeHeader('Name', 'a1', '/gdc/md/project_id/obj/123', 'attr.dataset.name', [new TotalHeaderItem('sum')]),
+        that new AttributeHeader('Name', 'a1', '/gdc/md/project_id/obj/123', 'attr.dataset.name', FORM_OF, [new TotalHeaderItem('sum')]),
                 jsonEquals(resource(ATTRIBUTE_HEADER_FULL_JSON))
     }
 
     def "should serialize"() {
         expect:
-        that new AttributeHeader('Name', 'a1', '/gdc/md/project_id/obj/123', 'attr.dataset.name'),
+        that new AttributeHeader('Name', 'a1', '/gdc/md/project_id/obj/123', 'attr.dataset.name', FORM_OF),
                 jsonEquals(resource(ATTRIBUTE_HEADER_JSON))
     }
 
@@ -38,6 +40,7 @@ class AttributeHeaderTest extends Specification {
         header.localIdentifier == 'a1'
         header.uri == '/gdc/md/project_id/obj/123'
         header.identifier == 'attr.dataset.name'
+        header.formOf == FORM_OF
     }
 
     def "should deserialize full"() {
@@ -49,6 +52,7 @@ class AttributeHeaderTest extends Specification {
         header.localIdentifier == 'a1'
         header.uri == '/gdc/md/project_id/obj/123'
         header.identifier == 'attr.dataset.name'
+        header.formOf == FORM_OF
         header.totalItems.size() == 1
         header.totalItems.first().name == 'sum'
         header.toString()

--- a/src/test/groovy/com/gooddata/executeafm/response/AttributeInHeaderTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/response/AttributeInHeaderTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.response
+
+import nl.jqno.equalsverifier.EqualsVerifier
+import spock.lang.Specification
+
+import static com.gooddata.util.ResourceUtils.readObjectFromResource
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals
+import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource
+import static spock.util.matcher.HamcrestSupport.that
+
+class AttributeInHeaderTest extends Specification {
+
+    private static final String ATTRIBUTE_IN_HEADER_JSON = 'executeafm/response/attributeInHeader.json'
+
+    def "should serialize"() {
+        expect:
+        that new AttributeInHeader('Some attr', '/gdc/md/project_id/obj/567', 'attr.some.id'),
+                jsonEquals(resource(ATTRIBUTE_IN_HEADER_JSON))
+    }
+
+    def "should deserialize"() {
+        when:
+        AttributeInHeader attributeInHeader = readObjectFromResource("/$ATTRIBUTE_IN_HEADER_JSON", AttributeInHeader)
+
+        then:
+        attributeInHeader.name == 'Some attr'
+        attributeInHeader.uri == '/gdc/md/project_id/obj/567'
+        attributeInHeader.identifier == 'attr.some.id'
+        attributeInHeader.toString()
+    }
+
+    def "should verify equals"() {
+        expect:
+        EqualsVerifier.forClass(AttributeInHeader).usingGetClass().verify()
+    }
+}

--- a/src/test/groovy/com/gooddata/executeafm/response/ExecutionResponseTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/response/ExecutionResponseTest.groovy
@@ -16,13 +16,15 @@ class ExecutionResponseTest extends Specification {
 
     private static final String EXECUTION_RESPONSE_JSON = 'executeafm/response/executionResponse.json'
 
+    private static final AttributeInHeader FORM_OF = new AttributeInHeader('Some attr', '/gdc/md/project_id/obj/567', 'attr.some.id')
+
     def "should serialize"() {
         expect:
         that new ExecutionResponse(
                 [
                         new ResultDimension(
-                                new AttributeHeader('Account', 'account', '/gdc/md/FoodMartDemo/obj/124', 'attr.account'),
-                                new AttributeHeader('Account Type', 'accountType', '/gdc/md/FoodMartDemo/obj/113', 'attr.accountType'),
+                                new AttributeHeader('Account', 'account', '/gdc/md/FoodMartDemo/obj/124', 'attr.account', FORM_OF),
+                                new AttributeHeader('Account Type', 'accountType', '/gdc/md/FoodMartDemo/obj/113', 'attr.accountType', FORM_OF),
                                 new MeasureGroupHeader([
                                         new MeasureHeaderItem('Accounting Amount [Sum]', 'format1', 'sum', '/gdc/md/FoodMartDemo/obj/114', 'metric.sum'),
                                         new MeasureHeaderItem('Accounting Amount [Avg]', 'format2', 'avg', '/gdc/md/FoodMartDemo/obj/115', 'metric.avg')

--- a/src/test/groovy/com/gooddata/executeafm/response/ResultDimensionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/response/ResultDimensionTest.groovy
@@ -17,10 +17,12 @@ class ResultDimensionTest extends Specification {
 
     private static final String RESULT_DIMENSION_JSON = 'executeafm/response/resultDimension.json'
 
+    private static final AttributeInHeader FORM_OF = new AttributeInHeader('Some attr', '/gdc/md/project_id/obj/567', 'attr.some.id')
+
     def "should serialize"() {
         expect:
         that new ResultDimension(
-                new AttributeHeader('Name', 'a1', '/gdc/md/project_id/obj/123', 'attr.dataset.name'),
+                new AttributeHeader('Name', 'a1', '/gdc/md/project_id/obj/123', 'attr.dataset.name', FORM_OF),
                 new MeasureGroupHeader([new MeasureHeaderItem('Name', '#,##0.00', 'm1')])),
                 jsonEquals(resource(RESULT_DIMENSION_JSON))
     }

--- a/src/test/resources/executeafm/response/attributeHeader.json
+++ b/src/test/resources/executeafm/response/attributeHeader.json
@@ -3,6 +3,11 @@
     "name": "Name",
     "localIdentifier": "a1",
     "uri": "/gdc/md/project_id/obj/123",
-    "identifier": "attr.dataset.name"
+    "identifier": "attr.dataset.name",
+    "formOf": {
+      "name": "Some attr",
+      "uri": "/gdc/md/project_id/obj/567",
+      "identifier": "attr.some.id"
+    }
   }
 }

--- a/src/test/resources/executeafm/response/attributeHeaderFull.json
+++ b/src/test/resources/executeafm/response/attributeHeaderFull.json
@@ -4,6 +4,11 @@
     "localIdentifier": "a1",
     "uri": "/gdc/md/project_id/obj/123",
     "identifier": "attr.dataset.name",
+    "formOf": {
+      "name": "Some attr",
+      "uri": "/gdc/md/project_id/obj/567",
+      "identifier": "attr.some.id"
+    },
     "totalItems": [
       {
         "totalHeaderItem": {

--- a/src/test/resources/executeafm/response/attributeInHeader.json
+++ b/src/test/resources/executeafm/response/attributeInHeader.json
@@ -1,0 +1,5 @@
+{
+  "name": "Some attr",
+  "uri": "/gdc/md/project_id/obj/567",
+  "identifier": "attr.some.id"
+}

--- a/src/test/resources/executeafm/response/executionResponse.json
+++ b/src/test/resources/executeafm/response/executionResponse.json
@@ -11,7 +11,12 @@
               "uri": "/gdc/md/FoodMartDemo/obj/124",
               "identifier": "attr.account",
               "name": "Account",
-              "localIdentifier": "account"
+              "localIdentifier": "account",
+              "formOf": {
+                "name": "Some attr",
+                "uri": "/gdc/md/project_id/obj/567",
+                "identifier": "attr.some.id"
+              }
             }
           },
           {
@@ -19,7 +24,12 @@
               "uri": "/gdc/md/FoodMartDemo/obj/113",
               "identifier": "attr.accountType",
               "name": "Account Type",
-              "localIdentifier": "accountType"
+              "localIdentifier": "accountType",
+              "formOf": {
+                "name": "Some attr",
+                "uri": "/gdc/md/project_id/obj/567",
+                "identifier": "attr.some.id"
+              }
             }
           },
           {

--- a/src/test/resources/executeafm/response/resultDimension.json
+++ b/src/test/resources/executeafm/response/resultDimension.json
@@ -5,7 +5,12 @@
         "name": "Name",
         "localIdentifier": "a1",
         "uri": "/gdc/md/project_id/obj/123",
-        "identifier": "attr.dataset.name"
+        "identifier": "attr.dataset.name",
+        "formOf": {
+          "name": "Some attr",
+          "uri": "/gdc/md/project_id/obj/567",
+          "identifier": "attr.some.id"
+        }
       }
     },
     {


### PR DESCRIPTION
The ExecutionResponse should inform client about which attribute does the header belongs to (not only display form)

Resolves #559 