### PR TITLE
Make `release.sh` Mac compatible

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -61,6 +61,6 @@ then
 fi
 
 mvn --batch-mode release:prepare release:perform -DreleaseVersion=${version} -Darguments="-Dgpg.passphrase=${gpg_pass}" 
-sed -i "s/\(<version>\)[0-9]*\.[0-9]*\.[0-9]*\(<\/version>\)/\1${version}\2/" README.md
+sed -i '' "s/\(<version>\)[0-9]*\.[0-9]*\.[0-9]*\(<\/version>\)/\1${version}\2/" README.md
 git commit -a -m "bump version"
 git push origin --tags HEAD


### PR DESCRIPTION
On Mac, we need to provide extension for backup-file - but when empty string is provided, it behaves exactly the same as `-i` (without argument) on Linux