### PR TITLE
Introduce support for Over period and Previous period measure definition

### DIFF
--- a/src/main/java/com/gooddata/executeafm/afm/MeasureDefinition.java
+++ b/src/main/java/com/gooddata/executeafm/afm/MeasureDefinition.java
@@ -8,10 +8,13 @@ package com.gooddata.executeafm.afm;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.gooddata.executeafm.IdentifierObjQualifier;
 import com.gooddata.executeafm.ObjQualifier;
 import com.gooddata.executeafm.UriObjQualifier;
 import com.gooddata.md.visualization.VOPopMeasureDefinition;
 import com.gooddata.md.visualization.VOSimpleMeasureDefinition;
+
+import java.util.Collection;
 
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
@@ -19,12 +22,15 @@ import com.gooddata.md.visualization.VOSimpleMeasureDefinition;
         @JsonSubTypes.Type(value = PopMeasureDefinition.class, name = PopMeasureDefinition.NAME),
         @JsonSubTypes.Type(value = VOSimpleMeasureDefinition.class, name = VOSimpleMeasureDefinition.NAME),
         @JsonSubTypes.Type(value = VOPopMeasureDefinition.class, name = VOPopMeasureDefinition.NAME),
+        @JsonSubTypes.Type(value = OverPeriodMeasureDefinition.class, name = OverPeriodMeasureDefinition.NAME),
+        @JsonSubTypes.Type(value = PreviousPeriodMeasureDefinition.class, name = PreviousPeriodMeasureDefinition.NAME),
 })
 public interface MeasureDefinition {
 
     /**
      * Returns the definition in the form of uri of {@link com.gooddata.md.Metric}.
      * Default implementation throws {@link UnsupportedOperationException}
+     *
      * @return uri of the measure
      */
     @JsonIgnore
@@ -34,17 +40,62 @@ public interface MeasureDefinition {
 
     /**
      * Returns the qualifier, qualifying the {@link com.gooddata.md.Metric}.
+     *
      * @return qualifier of measure
+     *
+     * @throws UnsupportedOperationException
+     *         The exception is thrown when the method is not supported by the implementation.
+     * @deprecated Use {@link #withObjUriQualifiers(ObjQualifierConverter)} instead as this method is not supported by all the existing implementations.
      */
     @JsonIgnore
+    @Deprecated
     ObjQualifier getObjQualifier();
 
     /**
-     * Copy itself using given uri qualifier
-     * @param qualifier qualifier to use for the new filter
-     * @return self copy with given qualifier
+     * Returns all the qualifiers used by the measure definition and its encapsulated objects.
+     * <p>
+     * This information comes handy if it is necessary, for example, to convert the measure definition to use just the URI object qualifiers instead of the
+     * identifier object qualifiers. It can be used to gather these for a conversion service.
+     *
+     * @return all the qualifiers the measure definition uses, even in its encapsulated objects (apart from the measure filters)
      */
+    @JsonIgnore
+    Collection<ObjQualifier> getObjQualifiers();
+
+    /**
+     * Copy itself using given URI qualifier.
+     *
+     * @param qualifier
+     *         The qualifier to use by the new object.
+     *
+     * @return self copy with given qualifier
+     *
+     * @throws UnsupportedOperationException
+     *         The exception is thrown when the method is not supported by the implementation.
+     * @deprecated Use {@link #withObjUriQualifiers(ObjQualifierConverter)} instead as this method is not supported by all the existing implementations.
+     */
+    @Deprecated
     MeasureDefinition withObjUriQualifier(UriObjQualifier qualifier);
+
+    /**
+     * Copy itself using the given object qualifier converter in case when {@link IdentifierObjQualifier} instances are used in the object otherwise the
+     * original object is returned.
+     * <p>
+     * The provided converter must be able to handle the conversion for the qualifiers that are of the {@link IdentifierObjQualifier} type that are used by
+     * this object or its encapsulated child objects.
+     *
+     * @param objQualifierConverter
+     *         The function that converts identifier qualifiers to the matching URI qualifiers. In case when the object uses the identifier qualifiers, it
+     *         will return a new copy of itself or its encapsulated objects that used URI qualifiers, otherwise the original object is returned.
+     *         The parameter must not be null.
+     *
+     * @return copy of itself with replaced qualifiers in case when some {@link IdentifierObjQualifier} were used, otherwise original object is returned.
+     *
+     * @throws IllegalArgumentException
+     *         The exception is thrown when conversion for the identifier qualifier used by this measure definition could not be made by the provided
+     *         converter or when provided converter is null.
+     */
+    MeasureDefinition withObjUriQualifiers(ObjQualifierConverter objQualifierConverter);
 
     /**
      * @return true if this definition represents ad hoc specified measure, false otherwise

--- a/src/main/java/com/gooddata/executeafm/afm/ObjIdentifierUtilities.java
+++ b/src/main/java/com/gooddata/executeafm/afm/ObjIdentifierUtilities.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.executeafm.afm;
+
+import com.gooddata.executeafm.IdentifierObjQualifier;
+import com.gooddata.executeafm.ObjQualifier;
+import com.gooddata.executeafm.UriObjQualifier;
+
+import java.util.function.Function;
+
+import static com.gooddata.util.Validate.notNull;
+import static java.lang.String.format;
+
+/**
+ * The utilities for conversion of the objects that use {@link IdentifierObjQualifier} to objects that use {@link UriObjQualifier}.
+ */
+abstract class ObjIdentifierUtilities {
+
+    /**
+     * Copy {@code objectToBeCopied} via provided {@code objectCopyFactory} in case when {@code qualifierForPossibleConversion} is of {@link
+     * IdentifierObjQualifier} type. Otherwise the original object is returned.
+     *
+     * @param objectToBeCopied
+     *         The object that should be copied in case {@code qualifierForPossibleConversion} is of {@link IdentifierObjQualifier} type. The parameter must
+     *         not be null.
+     * @param qualifierForPossibleConversion
+     *         The qualifier that defines if {@code objectToBeCopied} will be copied or not. In case when it is of the {@link IdentifierObjQualifier} type,
+     *         it will be converted via {@code qualifierConverter} and used in copy of the {@code objectToBeCopied}. The parameter must not be null.
+     * @param objectCopyFactory
+     *         The factory method that accepts the result of the {@code qualifierForPossibleConversion} conversion in form of {@link UriObjQualifier} and
+     *         returns new copy of the {@code objectToBeCopied}. The parameter must not be null.
+     * @param qualifierConverter
+     *         The convert that can convert {@code qualifierForPossibleConversion} into its matching {@link UriObjQualifier} form. The parameter must not be
+     *         null.
+     * @param <R>
+     *         The type of the object that should be copied.
+     *
+     * @return Copy of the {@code objectToBeCopied} in case when {@code qualifierForPossibleConversion} was of {@link IdentifierObjQualifier} type. Otherwise
+     * the original object is returned.
+     *
+     * @throws IllegalArgumentException
+     *         The exception is thrown when required parameter is null.
+     */
+    static <R> R copyIfNecessary(final R objectToBeCopied,
+                                 final ObjQualifier qualifierForPossibleConversion,
+                                 final Function<UriObjQualifier, R> objectCopyFactory,
+                                 final ObjQualifierConverter qualifierConverter) {
+        notNull(objectToBeCopied, "objectToBeCopied");
+        notNull(qualifierForPossibleConversion, "qualifierForPossibleConversion");
+        notNull(objectCopyFactory, "objectCopyFactory");
+        notNull(qualifierConverter, "qualifierConverter");
+
+        if (qualifierForPossibleConversion instanceof IdentifierObjQualifier) {
+            final IdentifierObjQualifier identifierQualifierToConvert = (IdentifierObjQualifier) qualifierForPossibleConversion;
+            return copyWithUriQualifier(identifierQualifierToConvert, objectCopyFactory, qualifierConverter);
+        }
+        return objectToBeCopied;
+    }
+
+    private static <R> R copyWithUriQualifier(final IdentifierObjQualifier identifierQualifierToConvert,
+                                              final Function<UriObjQualifier, R> objectCopyFactory,
+                                              final ObjQualifierConverter qualifierConverter) {
+        return qualifierConverter.convertToUriQualifier(identifierQualifierToConvert)
+                .map(objectCopyFactory)
+                .orElseThrow(() -> buildExceptionForFailedConversion(identifierQualifierToConvert));
+    }
+
+    private static IllegalArgumentException buildExceptionForFailedConversion(final IdentifierObjQualifier qualifierFailedToConvert) {
+        return new IllegalArgumentException(format("Supplied converter does not provide conversion for '%s'!", qualifierFailedToConvert));
+    }
+
+}

--- a/src/main/java/com/gooddata/executeafm/afm/ObjQualifierConverter.java
+++ b/src/main/java/com/gooddata/executeafm/afm/ObjQualifierConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.executeafm.afm;
+
+import com.gooddata.executeafm.IdentifierObjQualifier;
+import com.gooddata.executeafm.UriObjQualifier;
+
+import java.util.Optional;
+
+/**
+ * The interface of the function that converts {@link IdentifierObjQualifier} to the matching {@link UriObjQualifier}.
+ */
+@FunctionalInterface
+public interface ObjQualifierConverter {
+
+    /**
+     * Convert provided {@link IdentifierObjQualifier} to the matching {@link UriObjQualifier}.
+     *
+     * @param identifierObjQualifier
+     *         The identifier that must be converted.
+     *
+     * @return The optional matching {@link UriObjQualifier} obtained by the conversion.
+     */
+    Optional<UriObjQualifier> convertToUriQualifier(IdentifierObjQualifier identifierObjQualifier);
+}

--- a/src/main/java/com/gooddata/executeafm/afm/OverPeriodDateAttribute.java
+++ b/src/main/java/com/gooddata/executeafm/afm/OverPeriodDateAttribute.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gooddata.executeafm.ObjQualifier;
+import com.gooddata.util.GoodDataToStringBuilder;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static com.gooddata.util.Validate.notNull;
+
+/**
+ * Definition of the {@link OverPeriodMeasureDefinition} attribute.
+ */
+public class OverPeriodDateAttribute implements Serializable {
+
+    private static final long serialVersionUID = 2311364644023464059L;
+
+    private final ObjQualifier attribute;
+    private final Integer periodsAgo;
+
+    /**
+     * Create a new instance of {@link OverPeriodDateAttribute}.
+     *
+     * @param attribute
+     *         The {@link ObjQualifier} of the attribute from the date data set that defines the PoP period and date data set. The parameter must not be
+     *         null.
+     * @param periodsAgo
+     *         The number of periods defined by the {@code attribute} about which this period will be shifted about. The positive number shifts the period to
+     *         the past, the negative to the future. The parameter must not be null.
+     *
+     * @throws IllegalArgumentException
+     *         Thrown when one of the required parameter is null.
+     */
+    @JsonCreator
+    public OverPeriodDateAttribute(
+            @JsonProperty("attribute") final ObjQualifier attribute,
+            @JsonProperty("periodsAgo") final Integer periodsAgo) {
+        this.attribute = notNull(attribute, "attribute");
+        this.periodsAgo = notNull(periodsAgo, "periodsAgo");
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final OverPeriodDateAttribute that = (OverPeriodDateAttribute) o;
+        return Objects.equals(attribute, that.attribute) &&
+                Objects.equals(periodsAgo, that.periodsAgo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attribute, periodsAgo);
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+
+    /**
+     * The {@link ObjQualifier} of the attribute from the date data set that defines the PoP period.
+     *
+     * @return The date data set attribute that defines the PoP attribute.
+     */
+    public ObjQualifier getAttribute() {
+        return attribute;
+    }
+
+    /**
+     * The number of periods defined by the {@code attribute} about which this period will be shifted about. The positive number shifts the period to
+     * the past, the negative to the future.
+     *
+     * @return The number of periods the data will be shifted about.
+     */
+    public Integer getPeriodsAgo() {
+        return periodsAgo;
+    }
+}

--- a/src/main/java/com/gooddata/executeafm/afm/OverPeriodMeasureDefinition.java
+++ b/src/main/java/com/gooddata/executeafm/afm/OverPeriodMeasureDefinition.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.gooddata.executeafm.ObjQualifier;
+import com.gooddata.executeafm.UriObjQualifier;
+import com.gooddata.util.GoodDataToStringBuilder;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.gooddata.executeafm.afm.OverPeriodMeasureDefinition.NAME;
+import static com.gooddata.util.Validate.notEmpty;
+import static com.gooddata.util.Validate.notNull;
+
+/**
+ * Definition of the period over period measure that is used for the Same period last year and Same period 2 years back comparisons.
+ */
+@JsonRootName(NAME)
+public class OverPeriodMeasureDefinition implements MeasureDefinition, Serializable {
+
+    private static final long serialVersionUID = -8904516814279504098L;
+
+    static final String NAME = "overPeriodMeasure";
+
+    private final String measureIdentifier;
+    private final List<OverPeriodDateAttribute> dateAttributes;
+
+    /**
+     * Create a new instance of {@link OverPeriodMeasureDefinition}.
+     *
+     * @param measureIdentifier
+     *         The local identifier of the measure this PoP measure refers to. The parameter must not be null.
+     * @param dateAttributes
+     *         The date attributes that defines how this measure will be shifted in time. The parameter must not be null.
+     *
+     * @throws IllegalArgumentException
+     *         Thrown when {@code dateAttributes} list is empty or required parameter is null.
+     */
+    @JsonCreator
+    public OverPeriodMeasureDefinition(
+            @JsonProperty("measureIdentifier") final String measureIdentifier,
+            @JsonProperty("dateAttributes") final List<OverPeriodDateAttribute> dateAttributes) {
+        this.measureIdentifier = notNull(measureIdentifier, "measureIdentifier");
+        this.dateAttributes = notEmpty(dateAttributes, "dateAttributes");
+    }
+
+    /**
+     * The method is not supported by the object.
+     * Use {@link #getObjQualifiers()} instead.
+     *
+     * @return throws {@link UnsupportedOperationException}
+     *
+     * @throws UnsupportedOperationException
+     *         The exception is thrown every time the method is called.
+     * @deprecated Use {@link #getObjQualifiers()} instead.
+     */
+    @Override
+    @Deprecated
+    public ObjQualifier getObjQualifier() {
+        throw new UnsupportedOperationException("The method is not supported by the object!");
+    }
+
+    @Override
+    public Collection<ObjQualifier> getObjQualifiers() {
+        return this.dateAttributes.stream()
+                .map(OverPeriodDateAttribute::getAttribute)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * The method is not supported by the object.
+     * Use {@link #withObjUriQualifiers(ObjQualifierConverter)} instead.
+     *
+     * @param uriQualifier
+     *         The URI object qualifier.
+     *
+     * @return throws {@link UnsupportedOperationException}
+     *
+     * @throws UnsupportedOperationException
+     *         The exception is thrown every time the method is called.
+     * @deprecated Use {@link #withObjUriQualifiers(ObjQualifierConverter)} instead.
+     */
+    @Override
+    @Deprecated
+    public MeasureDefinition withObjUriQualifier(final UriObjQualifier uriQualifier) {
+        throw new UnsupportedOperationException("The method is not supported by the object!");
+    }
+
+    @Override
+    public MeasureDefinition withObjUriQualifiers(final ObjQualifierConverter objQualifierConverter) {
+        notNull(objQualifierConverter, "objQualifierConverter");
+        return new OverPeriodMeasureDefinition(measureIdentifier, copyAttributesWithUriQualifiers(objQualifierConverter));
+    }
+
+    private List<OverPeriodDateAttribute> copyAttributesWithUriQualifiers(final ObjQualifierConverter objQualifierConverter) {
+        return dateAttributes.stream()
+                .map(attribute -> copyWithUriQualifier(attribute, objQualifierConverter))
+                .collect(Collectors.toList());
+    }
+
+    private OverPeriodDateAttribute copyWithUriQualifier(final OverPeriodDateAttribute attribute, final ObjQualifierConverter objQualifierConverter) {
+        return ObjIdentifierUtilities.copyIfNecessary(
+                attribute,
+                attribute.getAttribute(),
+                uriObjQualifier -> new OverPeriodDateAttribute(uriObjQualifier, attribute.getPeriodsAgo()),
+                objQualifierConverter
+        );
+    }
+
+    /**
+     * Determine if measure is ad-hoc, i.e., if it does not exist in the catalog and was created on fly.
+     *
+     * @return always true ({@link OverPeriodMeasureDefinition} is always ad-hoc)
+     */
+    @Override
+    public boolean isAdHoc() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final OverPeriodMeasureDefinition that = (OverPeriodMeasureDefinition) o;
+        return Objects.equals(measureIdentifier, that.measureIdentifier) &&
+                Objects.equals(dateAttributes, that.dateAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(measureIdentifier, dateAttributes);
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+
+    /**
+     * The local identifier of the measure this PoP measure refers to.
+     *
+     * @return The local identifier of the master measure.
+     */
+    public String getMeasureIdentifier() {
+        return measureIdentifier;
+    }
+
+    /**
+     * The date attributes that defines how this measure will be shifted in time.
+     *
+     * @return The list of date attributes.
+     */
+    public List<OverPeriodDateAttribute> getDateAttributes() {
+        return dateAttributes;
+    }
+}

--- a/src/main/java/com/gooddata/executeafm/afm/PopMeasureDefinition.java
+++ b/src/main/java/com/gooddata/executeafm/afm/PopMeasureDefinition.java
@@ -31,8 +31,6 @@ public class PopMeasureDefinition implements MeasureDefinition, Serializable {
 
     private final ObjQualifier popAttribute;
 
-    private final Integer offset;
-
     /**
      * Creates new definition from given measure identifier referencing another measure in {@link Afm} and given attribute qualifier (should qualify date
      * attribute)
@@ -41,36 +39,17 @@ public class PopMeasureDefinition implements MeasureDefinition, Serializable {
      *         measure identifier
      * @param popAttribute
      *         "period over period" date attribute
-     * @param offset
-     *         the number of periods the time window defined by {@code popAttribute} is offset about to the past (when value is negative) or future (when
-     *         value is positive)
      */
     @JsonCreator
     public PopMeasureDefinition(@JsonProperty("measureIdentifier") final String measureIdentifier,
-                                @JsonProperty("popAttribute") final ObjQualifier popAttribute,
-                                @JsonProperty("offset") final Integer offset) {
+                                @JsonProperty("popAttribute") final ObjQualifier popAttribute) {
         this.measureIdentifier = measureIdentifier;
         this.popAttribute = popAttribute;
-        this.offset = offset;
-    }
-
-    /**
-     * Creates new definition from given measure identifier referencing another measure in {@link Afm} and given attribute qualifier (should qualify date
-     * attribute)
-     *
-     * @param measureIdentifier
-     *         measure identifier
-     * @param popAttribute
-     *         "period over period" date attribute
-     */
-    public PopMeasureDefinition(final String measureIdentifier,
-                                final ObjQualifier popAttribute) {
-        this(measureIdentifier, popAttribute, null);
     }
 
     @Override
     public MeasureDefinition withObjUriQualifier(final UriObjQualifier qualifier) {
-        return new PopMeasureDefinition(measureIdentifier, qualifier, offset);
+        return new PopMeasureDefinition(measureIdentifier, qualifier);
     }
 
     /**
@@ -87,15 +66,6 @@ public class PopMeasureDefinition implements MeasureDefinition, Serializable {
 
     public ObjQualifier getPopAttribute() {
         return popAttribute;
-    }
-
-    /**
-     * Returns number of periods defined via {@link #popAttribute} time interval.
-     *
-     * @return positive or negative number of periods or {@code null} when offset was not defined
-     */
-    public Integer getOffset() {
-        return offset;
     }
 
     @Override

--- a/src/main/java/com/gooddata/executeafm/afm/PreviousPeriodDateDataSet.java
+++ b/src/main/java/com/gooddata/executeafm/afm/PreviousPeriodDateDataSet.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gooddata.executeafm.ObjQualifier;
+import com.gooddata.util.GoodDataToStringBuilder;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static com.gooddata.util.Validate.notNull;
+
+/**
+ * Definition of the {@link PreviousPeriodMeasureDefinition} data set.
+ */
+public class PreviousPeriodDateDataSet implements Serializable {
+
+    private static final long serialVersionUID = 2311364644023464059L;
+
+    private final ObjQualifier dataSet;
+    private final Integer periodsAgo;
+
+    /**
+     * Create a new instance of {@link PreviousPeriodDateDataSet}.
+     *
+     * @param dataSet
+     *         The {@link ObjQualifier} of the data set that match one of the {@link DateFilter} in the execution. The parameter must not be null.
+     * @param periodsAgo
+     *         The number of periods defined by the matching date filter which this period will be shifted about. The positive number shifts the period to
+     *         the past, the negative to the future. The parameter must not be null.
+     *
+     * @throws IllegalArgumentException
+     *         Thrown when one of the required parameter is null.
+     */
+    @JsonCreator
+    public PreviousPeriodDateDataSet(
+            @JsonProperty("dataSet") final ObjQualifier dataSet,
+            @JsonProperty("periodsAgo") final Integer periodsAgo) {
+        this.dataSet = notNull(dataSet, "dataSet");
+        this.periodsAgo = notNull(periodsAgo, "periodsAgo");
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final PreviousPeriodDateDataSet that = (PreviousPeriodDateDataSet) o;
+        return Objects.equals(dataSet, that.dataSet) &&
+                Objects.equals(periodsAgo, that.periodsAgo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dataSet, periodsAgo);
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+
+    /**
+     * The {@link ObjQualifier} of the data set that match one of the {@link DateFilter} in the execution.
+     *
+     * @return The data set for matching of the AFM filter.
+     */
+    public ObjQualifier getDataSet() {
+        return dataSet;
+    }
+
+    /**
+     * The number of periods defined by the matching date filter which this period will be shifted about. The positive number shifts the period to
+     * the past, the negative to the future.
+     *
+     * @return The number of periods the data will be shifted about.
+     */
+    public Integer getPeriodsAgo() {
+        return periodsAgo;
+    }
+}

--- a/src/main/java/com/gooddata/executeafm/afm/PreviousPeriodMeasureDefinition.java
+++ b/src/main/java/com/gooddata/executeafm/afm/PreviousPeriodMeasureDefinition.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.gooddata.executeafm.ObjQualifier;
+import com.gooddata.executeafm.UriObjQualifier;
+import com.gooddata.util.GoodDataToStringBuilder;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.gooddata.executeafm.afm.PreviousPeriodMeasureDefinition.NAME;
+import static com.gooddata.util.Validate.notEmpty;
+import static com.gooddata.util.Validate.notNull;
+
+/**
+ * Definition of the period over period measure that is used for the Previous period comparison.
+ */
+@JsonRootName(NAME)
+public class PreviousPeriodMeasureDefinition implements MeasureDefinition, Serializable {
+
+    private static final long serialVersionUID = -4741355657671354062L;
+
+    static final String NAME = "previousPeriodMeasure";
+
+    private final String measureIdentifier;
+    private final List<PreviousPeriodDateDataSet> dateDataSets;
+
+    /**
+     * Create a new instance of {@link PreviousPeriodMeasureDefinition}.
+     *
+     * @param measureIdentifier
+     *         The local identifier of the measure this PoP measure refers to. The parameter must not be null.
+     * @param dateDataSets
+     *         The date data sets that defines how this measure will be shifted in time. The parameter must not be null.
+     *
+     * @throws IllegalArgumentException
+     *         Thrown when {@code attributes} list is empty or required parameter is null.
+     */
+    @JsonCreator
+    public PreviousPeriodMeasureDefinition(
+            @JsonProperty("measureIdentifier") final String measureIdentifier,
+            @JsonProperty("dateDataSets") final List<PreviousPeriodDateDataSet> dateDataSets) {
+        this.measureIdentifier = notNull(measureIdentifier, "measureIdentifier");
+        this.dateDataSets = notEmpty(dateDataSets, "dateDataSets");
+    }
+
+    /**
+     * The method is not supported by the object.
+     * Use {@link #getObjQualifiers()} instead.
+     *
+     * @return throws {@link UnsupportedOperationException}
+     *
+     * @throws UnsupportedOperationException
+     *         The exception is thrown every time the method is called.
+     * @deprecated Use {@link #getObjQualifiers()} instead.
+     */
+    @Override
+    @Deprecated
+    public ObjQualifier getObjQualifier() {
+        throw new UnsupportedOperationException("The method is not supported by the object!");
+    }
+
+    @Override
+    public Collection<ObjQualifier> getObjQualifiers() {
+        return this.dateDataSets.stream()
+                .map(PreviousPeriodDateDataSet::getDataSet)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * The method is not supported by the object.
+     * Use {@link #withObjUriQualifiers(ObjQualifierConverter)} instead.
+     *
+     * @param uriQualifier
+     *         The URI object qualifier.
+     *
+     * @return throws {@link UnsupportedOperationException}
+     *
+     * @throws UnsupportedOperationException
+     *         The exception is thrown every time the method is called.
+     * @deprecated Use {@link #withObjUriQualifiers(ObjQualifierConverter)} instead.
+     */
+    @Override
+    @Deprecated
+    public MeasureDefinition withObjUriQualifier(final UriObjQualifier uriQualifier) {
+        throw new UnsupportedOperationException("The method is not supported by the object!");
+    }
+
+    @Override
+    public MeasureDefinition withObjUriQualifiers(final ObjQualifierConverter objQualifierConverter) {
+        notNull(objQualifierConverter, "objQualifierConverter");
+        return new PreviousPeriodMeasureDefinition(measureIdentifier, copyDataSetsWithUriQualifiers(objQualifierConverter));
+    }
+
+    private List<PreviousPeriodDateDataSet> copyDataSetsWithUriQualifiers(final ObjQualifierConverter objQualifierConverter) {
+        return dateDataSets.stream()
+                .map(dataSet -> copyWithUriQualifier(dataSet, objQualifierConverter))
+                .collect(Collectors.toList());
+    }
+
+    private PreviousPeriodDateDataSet copyWithUriQualifier(final PreviousPeriodDateDataSet dataSet, final ObjQualifierConverter objQualifierConverter) {
+        return ObjIdentifierUtilities.copyIfNecessary(
+                dataSet,
+                dataSet.getDataSet(),
+                uriObjQualifier -> new PreviousPeriodDateDataSet(uriObjQualifier, dataSet.getPeriodsAgo()),
+                objQualifierConverter
+        );
+    }
+
+    /**
+     * Determine if measure is ad-hoc, i.e., if it does not exist in the catalog and was created on fly.
+     *
+     * @return always true ({@link PreviousPeriodMeasureDefinition} is always ad-hoc)
+     */
+    @Override
+    public boolean isAdHoc() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final PreviousPeriodMeasureDefinition that = (PreviousPeriodMeasureDefinition) o;
+        return Objects.equals(measureIdentifier, that.measureIdentifier) &&
+                Objects.equals(dateDataSets, that.dateDataSets);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(measureIdentifier, dateDataSets);
+    }
+
+    @Override
+    public String toString() {
+        return GoodDataToStringBuilder.defaultToString(this);
+    }
+
+    /**
+     * The local identifier of the measure this PoP measure refers to.
+     *
+     * @return The local identifier of the master measure.
+     */
+    public String getMeasureIdentifier() {
+        return measureIdentifier;
+    }
+
+    /**
+     * The date data sets that defines how this measure will be shifted in time.
+     *
+     * @return The list of date data sets.
+     */
+    public List<PreviousPeriodDateDataSet> getDateDataSets() {
+        return dateDataSets;
+    }
+}

--- a/src/main/java/com/gooddata/executeafm/afm/SimpleMeasureDefinition.java
+++ b/src/main/java/com/gooddata/executeafm/afm/SimpleMeasureDefinition.java
@@ -15,8 +15,11 @@ import com.gooddata.util.GoodDataToStringBuilder;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.gooddata.executeafm.afm.SimpleMeasureDefinition.NAME;
 import static com.gooddata.util.Validate.notNull;
@@ -43,10 +46,15 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Creates new definition
-     * @param item item which is measured, can be attribute, fact or another measure
-     * @param aggregation additional aggregation applied
-     * @param computeRatio whether should be shown as ratio
-     * @param filters additional filters applied
+     *
+     * @param item
+     *         item which is measured, can be attribute, fact or another measure
+     * @param aggregation
+     *         additional aggregation applied
+     * @param computeRatio
+     *         whether should be shown as ratio
+     * @param filters
+     *         additional filters applied
      */
     @JsonCreator
     public SimpleMeasureDefinition(@JsonProperty("item") final ObjQualifier item,
@@ -61,10 +69,15 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Creates new definition
-     * @param item item which is measured, can be attribute, fact or another measure
-     * @param aggregation additional aggregation applied
-     * @param computeRatio whether should be shown as ratio
-     * @param filters additional filters applied
+     *
+     * @param item
+     *         item which is measured, can be attribute, fact or another measure
+     * @param aggregation
+     *         additional aggregation applied
+     * @param computeRatio
+     *         whether should be shown as ratio
+     * @param filters
+     *         additional filters applied
      */
     public SimpleMeasureDefinition(final ObjQualifier item, final Aggregation aggregation, final Boolean computeRatio,
                                    final List<FilterItem> filters) {
@@ -73,19 +86,28 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Creates new definition
-     * @param item item which is measured, can be attribute, fact or another measure
-     * @param aggregation additional aggregation applied
-     * @param computeRatio whether should be shown as ratio
-     * @param filters additional filters applied
+     *
+     * @param item
+     *         item which is measured, can be attribute, fact or another measure
+     * @param aggregation
+     *         additional aggregation applied
+     * @param computeRatio
+     *         whether should be shown as ratio
+     * @param filters
+     *         additional filters applied
      */
-    public SimpleMeasureDefinition(final ObjQualifier item, final Aggregation aggregation, final Boolean computeRatio,
-                                   final FilterItem... filters) {
+    public SimpleMeasureDefinition(final ObjQualifier item, final Aggregation aggregation, final Boolean computeRatio, final FilterItem... filters) {
         this(item, aggregation, computeRatio, asList(filters));
     }
 
     @Override
-    public MeasureDefinition withObjUriQualifier(final UriObjQualifier qualifier) {
-        return new SimpleMeasureDefinition(qualifier, aggregation, computeRatio, filters);
+    public MeasureDefinition withObjUriQualifiers(final ObjQualifierConverter objQualifierConverter) {
+        return ObjIdentifierUtilities.copyIfNecessary(
+                this,
+                item,
+                uriObjQualifier -> new SimpleMeasureDefinition(uriObjQualifier, aggregation, computeRatio, filters),
+                objQualifierConverter
+        );
     }
 
     @Override
@@ -98,9 +120,42 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
         return getItem().getUri();
     }
 
+    /**
+     * Returns the qualifier used by the {@link com.gooddata.md.Metric}.
+     *
+     * @return qualifier used by the metric, which is its {@link #item}. The null is returned in case when {@link #item} was not set.
+     *
+     * @deprecated Use {@link #getObjQualifiers()} instead.
+     */
     @Override
+    @Deprecated
     public ObjQualifier getObjQualifier() {
-        return getItem();
+        return getObjQualifiers().stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public Collection<ObjQualifier> getObjQualifiers() {
+        return item == null
+                ? Collections.emptySet()
+                : Collections.singleton(item);
+    }
+
+    /**
+     * Copy itself using given URI qualifier.
+     *
+     * @param uriQualifier
+     *         The qualifier to use by the new object instead of the currently used one.
+     *
+     * @return self copy with given qualifier
+     *
+     * @deprecated Use {@link #withObjUriQualifiers(ObjQualifierConverter)} instead.
+     */
+    @Override
+    @Deprecated
+    public MeasureDefinition withObjUriQualifier(final UriObjQualifier uriQualifier) {
+        return withObjUriQualifiers((identifierObjQualifier) -> Optional.of(uriQualifier));
     }
 
     /**
@@ -119,7 +174,9 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Set additional aggregation applied
-     * @param aggregation additional aggregation applied
+     *
+     * @param aggregation
+     *         additional aggregation applied
      */
     public void setAggregation(final String aggregation) {
         this.aggregation = aggregation;
@@ -127,7 +184,9 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Set additional aggregation applied
-     * @param aggregation additional aggregation applied
+     *
+     * @param aggregation
+     *         additional aggregation applied
      */
     public void setAggregation(final Aggregation aggregation) {
         setAggregation(notNull(aggregation, "aggregation").toString());
@@ -142,7 +201,9 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Set whether should be shown as ratio
-     * @param computeRatio whether should be shown as ratio
+     *
+     * @param computeRatio
+     *         whether should be shown as ratio
      */
     public void setComputeRatio(final Boolean computeRatio) {
         this.computeRatio = computeRatio;
@@ -157,7 +218,9 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Set additional filters applied
-     * @param filters additional filters applied
+     *
+     * @param filters
+     *         additional filters applied
      */
     public void setFilters(final List<FilterItem> filters) {
         this.filters = filters;
@@ -165,7 +228,9 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
 
     /**
      * Apply additional filter
-     * @param filter filter to be applied
+     *
+     * @param filter
+     *         filter to be applied
      */
     public void addFilter(final FilterItem filter) {
         if (filters == null) {
@@ -193,6 +258,22 @@ public class SimpleMeasureDefinition implements MeasureDefinition, Serializable 
      */
     public boolean hasAggregation() {
         return aggregation != null;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final SimpleMeasureDefinition that = (SimpleMeasureDefinition) o;
+        return Objects.equals(item, that.item) &&
+                Objects.equals(aggregation, that.aggregation) &&
+                Objects.equals(computeRatio, that.computeRatio) &&
+                Objects.equals(filters, that.filters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(item, aggregation, computeRatio, filters);
     }
 
     @Override

--- a/src/main/java/com/gooddata/md/visualization/VOPopMeasureDefinition.java
+++ b/src/main/java/com/gooddata/md/visualization/VOPopMeasureDefinition.java
@@ -33,27 +33,11 @@ public class VOPopMeasureDefinition extends com.gooddata.executeafm.afm.PopMeasu
      *         reference to local identifier of {@link VOSimpleMeasureDefinition} over which is PoP calculated
      * @param popAttribute
      *         uri to attribute used for PoP
-     * @param offset
-     *         the number of periods defined via the {@code popAttribute} time interval to the past (when value is negative) or to the future (when
-     *         value is positive)
      */
     @JsonCreator
     public VOPopMeasureDefinition(@JsonProperty("measureIdentifier") final String measureIdentifier,
-                                  @JsonProperty("popAttribute") final ObjQualifier popAttribute,
-                                  @JsonProperty("offset") final Integer offset) {
-        super(measureIdentifier, popAttribute, offset);
-    }
-
-    /**
-     * Creates instance of Period over Period measure definition to be used in {@link VisualizationObject}
-     *
-     * @param measureIdentifier
-     *         reference to local identifier of {@link VOSimpleMeasureDefinition} over which is PoP calculated
-     * @param popAttribute
-     *         uri to attribute used for PoP
-     */
-    public VOPopMeasureDefinition(final String measureIdentifier,
-                                  final ObjQualifier popAttribute) {
+                                  @JsonProperty("popAttribute") final ObjQualifier popAttribute) {
         super(measureIdentifier, popAttribute);
     }
+
 }

--- a/src/test/groovy/com/gooddata/executeafm/afm/MeasureDefinitionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/afm/MeasureDefinitionTest.groovy
@@ -21,9 +21,11 @@ class MeasureDefinitionTest extends Specification {
         typeClass.isInstance(instance)
 
         where:
-        type                      | typeClass
-        'popMeasureDefinition'    | PopMeasureDefinition
-        'simpleMeasureDefinition' | SimpleMeasureDefinition
+        type                              | typeClass
+        'popMeasureDefinition'            | PopMeasureDefinition
+        'simpleMeasureDefinition'         | SimpleMeasureDefinition
+        'overPeriodMeasureDefinition'     | OverPeriodMeasureDefinition
+        'previousPeriodMeasureDefinition' | PreviousPeriodMeasureDefinition
     }
 
     def "getUri() should throw exception"() {

--- a/src/test/groovy/com/gooddata/executeafm/afm/ObjIdentifierUtilitiesTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/afm/ObjIdentifierUtilitiesTest.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.executeafm.afm
+
+import com.gooddata.executeafm.IdentifierObjQualifier
+import com.gooddata.executeafm.ObjQualifier
+import com.gooddata.executeafm.UriObjQualifier
+import spock.lang.Specification
+
+class ObjIdentifierUtilitiesTest extends Specification {
+
+
+    def "should throw when required parameter is null"() {
+        when:
+        ObjIdentifierUtilities.copyIfNecessary(objectToCopy, qualifier, copyFactory, converter)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        objectToCopy | qualifier                        | copyFactory             | converter
+        null         | new IdentifierObjQualifier("id") | { uri -> "new string" } | { id -> new UriObjQualifier("/uri") }
+        "string"     | null                             | { uri -> "new string" } | { id -> new UriObjQualifier("/uri") }
+        "string"     | new IdentifierObjQualifier("id") | null                    | { id -> new UriObjQualifier("/uri") }
+        "string"     | new IdentifierObjQualifier("id") | { uri -> "new string" } | null
+    }
+
+    def "should throw when uri conversion failed"() {
+        given:
+        SomeClass original = new SomeClass(new IdentifierObjQualifier("id"))
+        def copyFactory = { uriQualifier -> new SomeClass(uriQualifier) }
+        def qualifiersConversionMap = [
+                (new IdentifierObjQualifier("another-id")): new UriObjQualifier("/uri")
+        ]
+        ObjQualifierConverter qualifierConverter = { identifierQualifier ->
+            return Optional.ofNullable(qualifiersConversionMap.get(identifierQualifier))
+        }
+
+        when:
+        ObjIdentifierUtilities.copyIfNecessary(original, original.qualifier, copyFactory, qualifierConverter)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "should return copied object with result of the qualifier result"() {
+        given:
+        SomeClass original = new SomeClass(new IdentifierObjQualifier("id"))
+        def copyFactory = { uriQualifier -> new SomeClass(uriQualifier) }
+        def qualifiersConversionMap = [
+                (new IdentifierObjQualifier("id")): new UriObjQualifier("/uri")
+        ]
+        ObjQualifierConverter qualifierConverter = { identifierQualifier ->
+            return Optional.ofNullable(qualifiersConversionMap.get(identifierQualifier))
+        }
+
+        when:
+        SomeClass copy = ObjIdentifierUtilities.copyIfNecessary(original, original.qualifier, copyFactory, qualifierConverter)
+
+        then:
+        copy == new SomeClass(new UriObjQualifier("/uri"))
+    }
+
+    def "should return the original object when it already uses the uri qualifier"() {
+        given:
+        SomeClass original = new SomeClass(new UriObjQualifier("/uri"))
+        def copyFactory = { uriQualifier -> new SomeClass(uriQualifier) }
+        def qualifiersConversionMap = [
+                (new IdentifierObjQualifier("id")): new UriObjQualifier("/another-uri")
+        ]
+        ObjQualifierConverter qualifierConverter = { identifierQualifier ->
+            return Optional.ofNullable(qualifiersConversionMap.get(identifierQualifier))
+        }
+
+        when:
+        SomeClass copy = ObjIdentifierUtilities.copyIfNecessary(original, original.qualifier, copyFactory, qualifierConverter)
+
+        then:
+        original == copy
+    }
+
+    private class SomeClass {
+
+        private ObjQualifier qualifier
+
+        SomeClass(ObjQualifier qualifier) {
+            this.qualifier = qualifier
+        }
+
+        boolean equals(final o) {
+            if (this.is(o)) return true
+            if (getClass() != o.class) return false
+            SomeClass someClass = (SomeClass) o
+            if (qualifier != someClass.qualifier) return false
+            return true
+        }
+
+        int hashCode() {
+            return (qualifier != null ? qualifier.hashCode() : 0)
+        }
+    }
+}

--- a/src/test/groovy/com/gooddata/executeafm/afm/OverPeriodDateAttributeTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/afm/OverPeriodDateAttributeTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm
+
+import com.gooddata.executeafm.UriObjQualifier
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.apache.commons.lang3.SerializationUtils
+import spock.lang.Specification
+
+import static com.gooddata.util.ResourceUtils.readObjectFromResource
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals
+import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource
+import static spock.util.matcher.HamcrestSupport.that
+
+class OverPeriodDateAttributeTest extends Specification {
+
+    private static final String ATTRIBUTE_JSON = "executeafm/afm/overPeriodDateAttribute.json"
+
+    def "should serialize"() {
+        expect:
+        OverPeriodDateAttribute dateAttribute = new OverPeriodDateAttribute(
+                new UriObjQualifier('/gdc/md/projectId/obj/1'), 2)
+        that dateAttribute, jsonEquals(resource(ATTRIBUTE_JSON))
+    }
+
+    def "should deserialize"() {
+        when:
+        OverPeriodDateAttribute dateAttribute = readObjectFromResource("/$ATTRIBUTE_JSON", OverPeriodDateAttribute)
+
+        then:
+        dateAttribute.attribute.uri == '/gdc/md/projectId/obj/1'
+        dateAttribute.periodsAgo == 2
+    }
+
+    def "test serializable"() {
+        given:
+        OverPeriodDateAttribute dateAttribute = readObjectFromResource("/$ATTRIBUTE_JSON", OverPeriodDateAttribute)
+        OverPeriodDateAttribute deserialized = SerializationUtils.roundtrip(dateAttribute)
+
+        expect:
+        that deserialized, jsonEquals(dateAttribute)
+    }
+
+    def "should throw when required construction parameter is null"() {
+        when:
+        new OverPeriodDateAttribute(attribute, periodsAgo)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        attribute                                      | periodsAgo
+        null                                           | 2
+        new UriObjQualifier('/gdc/md/projectId/obj/1') | null
+    }
+
+    def "should verify equals"() {
+        expect:
+        EqualsVerifier.forClass(OverPeriodDateAttribute)
+                .usingGetClass()
+                .verify()
+    }
+}

--- a/src/test/groovy/com/gooddata/executeafm/afm/OverPeriodMeasureDefinitionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/afm/OverPeriodMeasureDefinitionTest.groovy
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm
+
+import com.gooddata.executeafm.IdentifierObjQualifier
+import com.gooddata.executeafm.UriObjQualifier
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.apache.commons.lang3.SerializationUtils
+import spock.lang.Specification
+
+import static com.gooddata.util.ResourceUtils.readObjectFromResource
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals
+import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource
+import static spock.util.matcher.HamcrestSupport.that
+
+class OverPeriodMeasureDefinitionTest extends Specification {
+
+    private static final String path = 'executeafm/afm'
+    private static final String SINGLE_ATTRIBUTE_JSON = "$path/overPeriodMeasureDefinition.json"
+    private static final String TWO_ATTRIBUTES_JSON = "$path/overPeriodMeasureDefinitionWithTwoAttributes.json"
+
+    def "should serialize"() {
+        expect:
+        OverPeriodMeasureDefinition measure = new OverPeriodMeasureDefinition(
+                'mId', [new OverPeriodDateAttribute(new UriObjQualifier('/gdc/md/projectId/obj/1'), 2)]
+        )
+        that measure, jsonEquals(resource(SINGLE_ATTRIBUTE_JSON))
+    }
+
+    def "should deserialize when single attribute is provided"() {
+        when:
+        OverPeriodMeasureDefinition measure = readObjectFromResource("/$SINGLE_ATTRIBUTE_JSON", OverPeriodMeasureDefinition)
+
+        then:
+        measure.measureIdentifier == 'mId'
+        measure.getObjQualifiers()[0].uri == '/gdc/md/projectId/obj/1'
+        measure.dateAttributes.size() == 1
+        measure.dateAttributes[0].periodsAgo == 2
+        measure.dateAttributes[0].attribute.uri == '/gdc/md/projectId/obj/1'
+        measure.isAdHoc()
+        measure.toString()
+    }
+
+    def "should deserialize when more attributes are provided"() {
+        when:
+        OverPeriodMeasureDefinition measure = readObjectFromResource("/$TWO_ATTRIBUTES_JSON", OverPeriodMeasureDefinition)
+
+        then:
+        measure.measureIdentifier == 'mId'
+        measure.getObjQualifiers()[0].uri == '/gdc/md/projectId/obj/1'
+        measure.getObjQualifiers()[1].uri == '/gdc/md/projectId/obj/2'
+        measure.dateAttributes.size() == 2
+        measure.dateAttributes[0].periodsAgo == 2
+        measure.dateAttributes[0].attribute.uri == '/gdc/md/projectId/obj/1'
+        measure.dateAttributes[1].periodsAgo == 1
+        measure.dateAttributes[1].attribute.uri == '/gdc/md/projectId/obj/2'
+        measure.isAdHoc()
+        measure.toString()
+    }
+
+    def "test serializable"() {
+        given:
+        OverPeriodMeasureDefinition measureDefinition = readObjectFromResource("/$SINGLE_ATTRIBUTE_JSON", OverPeriodMeasureDefinition)
+        OverPeriodMeasureDefinition deserialized = SerializationUtils.roundtrip(measureDefinition)
+
+        expect:
+        that deserialized, jsonEquals(measureDefinition)
+    }
+
+    def "should throw when required construction parameter is null or empty"() {
+        when:
+        new OverPeriodMeasureDefinition(measureIdentifier, dateAttributes)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        measureIdentifier | dateAttributes
+        'mId'             | null
+        'mId'             | []
+        null              | [new OverPeriodDateAttribute(new UriObjQualifier('/gdc/md/projectId/obj/1'), 2)]
+    }
+
+    def "should throw when getting used object qualifiers via deprecated method"() {
+        when:
+        OverPeriodMeasureDefinition measure = new OverPeriodMeasureDefinition('mId', [
+                new OverPeriodDateAttribute(new IdentifierObjQualifier('id1'), -2),
+        ])
+        measure.getObjQualifier()
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "should throw when try to copy with uri via deprecated method"() {
+        when:
+        OverPeriodMeasureDefinition measure = new OverPeriodMeasureDefinition('mId', [
+                new OverPeriodDateAttribute(new IdentifierObjQualifier('id1'), -2),
+        ])
+        measure.withObjUriQualifier(new UriObjQualifier("/gdc/md/projectId/obj/1"))
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "should copy with uri converter"() {
+        when:
+        OverPeriodMeasureDefinition measure = new OverPeriodMeasureDefinition('mId', [
+                new OverPeriodDateAttribute(new IdentifierObjQualifier('id1'), -2),
+                new OverPeriodDateAttribute(new IdentifierObjQualifier('id2'), -3),
+                new OverPeriodDateAttribute(new UriObjQualifier('/gdc/md/projectId/obj/3'), -4)
+        ])
+        def qualifiersConversionMap = [
+                (new IdentifierObjQualifier("id2")): new UriObjQualifier("/gdc/md/projectId/obj/2"),
+                (new IdentifierObjQualifier("id1")): new UriObjQualifier("/gdc/md/projectId/obj/1")
+        ]
+        def copy = measure.withObjUriQualifiers({ identifierQualifier ->
+            return Optional.ofNullable(qualifiersConversionMap.get(identifierQualifier))
+        })
+
+        then:
+        measure.measureIdentifier == 'mId'
+        copy.dateAttributes[0].attribute.uri == '/gdc/md/projectId/obj/1'
+        copy.dateAttributes[0].periodsAgo == -2
+        copy.dateAttributes[1].attribute.uri == '/gdc/md/projectId/obj/2'
+        copy.dateAttributes[1].periodsAgo == -3
+        copy.dateAttributes[2].attribute.uri == '/gdc/md/projectId/obj/3'
+        copy.dateAttributes[2].periodsAgo == -4
+    }
+
+    def "should fail when qualifier converter is not provided or cannot convert object's identifier qualifiers"() {
+        when:
+        OverPeriodMeasureDefinition measure = new OverPeriodMeasureDefinition('mId', [
+                new OverPeriodDateAttribute(new IdentifierObjQualifier('id1'), -2)
+        ])
+        measure.withObjUriQualifiers(invalidObjQualifierConverter)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        invalidObjQualifierConverter << [null, { identifierQualifier -> Optional.empty() }]
+    }
+
+    def "should verify equals"() {
+        expect:
+        EqualsVerifier.forClass(OverPeriodMeasureDefinition)
+                .usingGetClass()
+                .verify()
+    }
+}

--- a/src/test/groovy/com/gooddata/executeafm/afm/PopMeasureDefinitionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/afm/PopMeasureDefinitionTest.groovy
@@ -17,64 +17,40 @@ import static spock.util.matcher.HamcrestSupport.that
 
 class PopMeasureDefinitionTest extends Specification {
 
-    private static final String POP_MEASURE_JSON = 'executeafm/afm/popMeasureDefinition.json'
-    private static final String POP_MEASURE_WITH_OFFSET_JSON = 'executeafm/afm/popMeasureDefinitionWithOffset.json'
-
+    private static final String POP_MEASURE_DEFINITION_JSON = 'executeafm/afm/popMeasureDefinition.json'
 
     def "should serialize"() {
         expect:
-        that new PopMeasureDefinition('mId', new UriObjQualifier('/gdc/md/projectId/obj/1'), offset),
-                jsonEquals(resource(expectedJsonMeasureDefinition))
-
-        where:
-        offset | expectedJsonMeasureDefinition
-        null   | POP_MEASURE_JSON
-        -2     | POP_MEASURE_WITH_OFFSET_JSON
+        that new PopMeasureDefinition('mId', new UriObjQualifier('/gdc/md/projectId/obj/1')),
+                jsonEquals(resource(POP_MEASURE_DEFINITION_JSON))
     }
 
     def "should deserialize"() {
         when:
-        PopMeasureDefinition measure = readObjectFromResource("/$jsonMeasureDefinition", PopMeasureDefinition)
+        PopMeasureDefinition measure = readObjectFromResource("/$POP_MEASURE_DEFINITION_JSON", PopMeasureDefinition)
 
         then:
         measure.measureIdentifier == 'mId'
         (measure.popAttribute as UriObjQualifier).uri == '/gdc/md/projectId/obj/1'
         measure.isAdHoc()
         measure.toString()
-        measure.offset == expectedOffset
-
-        where:
-        jsonMeasureDefinition        | expectedOffset
-        POP_MEASURE_JSON             | null
-        POP_MEASURE_WITH_OFFSET_JSON | -2
     }
 
     def "should copy"() {
         when:
-        def measure = new PopMeasureDefinition("mId", new IdentifierObjQualifier("id"), inputOffset)
+        def measure = new PopMeasureDefinition("mid", new IdentifierObjQualifier("id"))
         def copy = measure.withObjUriQualifier(new UriObjQualifier("uri"))
 
         then:
-        copy.measureIdentifier == 'mId'
         copy.objQualifier.uri == 'uri'
-        copy.offset == expectedOffset
-
-        where:
-        inputOffset | expectedOffset
-        null        | null
-        -2          | -2
     }
 
     def "test serializable"() {
-        when:
-        PopMeasureDefinition measureDefinition = readObjectFromResource("/$jsonMeasureDefinition", PopMeasureDefinition)
+        PopMeasureDefinition measureDefinition = readObjectFromResource("/$POP_MEASURE_DEFINITION_JSON", PopMeasureDefinition)
         PopMeasureDefinition deserialized = SerializationUtils.roundtrip(measureDefinition)
 
-        then:
+        expect:
         that deserialized, jsonEquals(measureDefinition)
-
-        where:
-        jsonMeasureDefinition << [POP_MEASURE_JSON, POP_MEASURE_WITH_OFFSET_JSON]
     }
 
 }

--- a/src/test/groovy/com/gooddata/executeafm/afm/PreviousPeriodDateDataSetTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/afm/PreviousPeriodDateDataSetTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm
+
+import com.gooddata.executeafm.UriObjQualifier
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.apache.commons.lang3.SerializationUtils
+import spock.lang.Specification
+
+import static com.gooddata.util.ResourceUtils.readObjectFromResource
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals
+import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource
+import static spock.util.matcher.HamcrestSupport.that
+
+class PreviousPeriodDateDataSetTest extends Specification {
+
+    private static final String DATA_SET_JSON = "executeafm/afm/previousPeriodDateDataSet.json"
+
+    def "should serialize"() {
+        expect:
+        PreviousPeriodDateDataSet dateDataSet = new PreviousPeriodDateDataSet(
+                new UriObjQualifier('/gdc/md/projectId/obj/1'), 2)
+        that dateDataSet, jsonEquals(resource(DATA_SET_JSON))
+    }
+
+    def "should deserialize"() {
+        when:
+        PreviousPeriodDateDataSet dateDataSet = readObjectFromResource("/$DATA_SET_JSON", PreviousPeriodDateDataSet)
+
+        then:
+        dateDataSet.dataSet.uri == '/gdc/md/projectId/obj/1'
+        dateDataSet.periodsAgo == 2
+    }
+
+    def "test serializable"() {
+        given:
+        PreviousPeriodDateDataSet dateDataSet = readObjectFromResource("/$DATA_SET_JSON", PreviousPeriodDateDataSet)
+        PreviousPeriodDateDataSet deserialized = SerializationUtils.roundtrip(dateDataSet)
+
+        expect:
+        that deserialized, jsonEquals(dateDataSet)
+    }
+
+    def "should throw when required construction parameter is null"() {
+        when:
+        new PreviousPeriodDateDataSet(dateDataSet, periodsAgo)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        dateDataSet                                    | periodsAgo
+        null                                           | 2
+        new UriObjQualifier('/gdc/md/projectId/obj/1') | null
+    }
+
+    def "should verify equals"() {
+        expect:
+        EqualsVerifier.forClass(PreviousPeriodDateDataSet)
+                .usingGetClass()
+                .verify()
+    }
+}

--- a/src/test/groovy/com/gooddata/executeafm/afm/PreviousPeriodMeasureDefinitionTest.groovy
+++ b/src/test/groovy/com/gooddata/executeafm/afm/PreviousPeriodMeasureDefinitionTest.groovy
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2007-2018, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.executeafm.afm
+
+import com.gooddata.executeafm.IdentifierObjQualifier
+import com.gooddata.executeafm.UriObjQualifier
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.apache.commons.lang3.SerializationUtils
+import spock.lang.Specification
+
+import static com.gooddata.util.ResourceUtils.readObjectFromResource
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals
+import static net.javacrumbs.jsonunit.core.util.ResourceUtils.resource
+import static spock.util.matcher.HamcrestSupport.that
+
+class PreviousPeriodMeasureDefinitionTest extends Specification {
+
+    private static final String path = 'executeafm/afm'
+    private static final String SINGLE_DATA_SET_JSON = "$path/previousPeriodMeasureDefinition.json"
+    private static final String TWO_DATA_SETS_JSON = "$path/previousPeriodMeasureDefinitionWithTwoDataSets.json"
+
+    def "should serialize"() {
+        expect:
+        PreviousPeriodMeasureDefinition measure = new PreviousPeriodMeasureDefinition(
+                'mId', [new PreviousPeriodDateDataSet(new UriObjQualifier('/gdc/md/projectId/obj/1'), 2)]
+        )
+        that measure, jsonEquals(resource(SINGLE_DATA_SET_JSON))
+    }
+
+    def "should deserialize when single attribute is provided"() {
+        when:
+        PreviousPeriodMeasureDefinition measure = readObjectFromResource("/$SINGLE_DATA_SET_JSON", PreviousPeriodMeasureDefinition)
+
+        then:
+        measure.measureIdentifier == 'mId'
+        measure.getObjQualifiers()[0].uri == '/gdc/md/projectId/obj/1'
+        measure.dateDataSets.size() == 1
+        measure.dateDataSets[0].periodsAgo == 2
+        measure.dateDataSets[0].dataSet.uri == '/gdc/md/projectId/obj/1'
+        measure.isAdHoc()
+        measure.toString()
+    }
+
+    def "should deserialize when more attributes are provided"() {
+        when:
+        PreviousPeriodMeasureDefinition measure = readObjectFromResource("/$TWO_DATA_SETS_JSON", PreviousPeriodMeasureDefinition)
+
+        then:
+        measure.measureIdentifier == 'mId'
+        measure.getObjQualifiers()[0].uri == '/gdc/md/projectId/obj/1'
+        measure.getObjQualifiers()[1].uri == '/gdc/md/projectId/obj/2'
+        measure.dateDataSets.size() == 2
+        measure.dateDataSets[0].periodsAgo == 2
+        measure.dateDataSets[0].dataSet.uri == '/gdc/md/projectId/obj/1'
+        measure.dateDataSets[1].periodsAgo == 1
+        measure.dateDataSets[1].dataSet.uri == '/gdc/md/projectId/obj/2'
+        measure.isAdHoc()
+        measure.toString()
+    }
+
+    def "test serializable"() {
+        given:
+        PreviousPeriodMeasureDefinition measureDefinition = readObjectFromResource("/$SINGLE_DATA_SET_JSON", PreviousPeriodMeasureDefinition)
+        PreviousPeriodMeasureDefinition deserialized = SerializationUtils.roundtrip(measureDefinition)
+
+        expect:
+        that deserialized, jsonEquals(measureDefinition)
+    }
+
+    def "should throw when required construction parameter is null or empty"() {
+        when:
+        new PreviousPeriodMeasureDefinition(measureIdentifier, dateDataSets)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        measureIdentifier | dateDataSets
+        'mId'             | null
+        'mId'             | []
+        null              | [new PreviousPeriodDateDataSet(new UriObjQualifier('/gdc/md/projectId/obj/1'), 2)]
+    }
+
+    def "should throw when getting used object qualifiers via deprecated method"() {
+        when:
+        PreviousPeriodMeasureDefinition measure = new PreviousPeriodMeasureDefinition('mId', [
+                new PreviousPeriodDateDataSet(new IdentifierObjQualifier('id1'), -2),
+        ])
+        measure.getObjQualifier()
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "should throw when try to copy with uri via deprecated method"() {
+        when:
+        PreviousPeriodMeasureDefinition measure = new PreviousPeriodMeasureDefinition('mId', [
+                new PreviousPeriodDateDataSet(new IdentifierObjQualifier('id1'), -2),
+        ])
+        measure.withObjUriQualifier(new UriObjQualifier("/gdc/md/projectId/obj/1"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "should copy with uri converter"() {
+        when:
+        PreviousPeriodMeasureDefinition measure = new PreviousPeriodMeasureDefinition('mId', [
+                new PreviousPeriodDateDataSet(new IdentifierObjQualifier('id1'), -2),
+                new PreviousPeriodDateDataSet(new IdentifierObjQualifier('id2'), -3),
+                new PreviousPeriodDateDataSet(new UriObjQualifier('/gdc/md/projectId/obj/3'), -4)
+        ])
+        def qualifiersConversionMap = [
+                (new IdentifierObjQualifier("id2")): new UriObjQualifier("/gdc/md/projectId/obj/2"),
+                (new IdentifierObjQualifier("id1")): new UriObjQualifier("/gdc/md/projectId/obj/1")
+        ]
+        def copy = measure.withObjUriQualifiers({ identifierQualifier ->
+            return Optional.ofNullable(qualifiersConversionMap.get(identifierQualifier))
+        })
+
+        then:
+        measure.measureIdentifier == 'mId'
+        copy.dateDataSets[0].dataSet.uri == '/gdc/md/projectId/obj/1'
+        copy.dateDataSets[0].periodsAgo == -2
+        copy.dateDataSets[1].dataSet.uri == '/gdc/md/projectId/obj/2'
+        copy.dateDataSets[1].periodsAgo == -3
+        copy.dateDataSets[2].dataSet.uri == '/gdc/md/projectId/obj/3'
+        copy.dateDataSets[2].periodsAgo == -4
+    }
+
+    def "should fail when qualifier converter is not provided or cannot convert object's identifier qualifiers"() {
+        when:
+        PreviousPeriodMeasureDefinition measure = new PreviousPeriodMeasureDefinition('mId', [
+                new PreviousPeriodDateDataSet(new IdentifierObjQualifier('id1'), -2)
+        ])
+        measure.withObjUriQualifiers(invalidObjQualifierConverter)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        invalidObjQualifierConverter << [null, { identifierQualifier -> Optional.empty() }]
+    }
+
+    def "should verify equals"() {
+        expect:
+        EqualsVerifier.forClass(PreviousPeriodMeasureDefinition)
+                .usingGetClass()
+                .verify()
+    }
+}

--- a/src/test/resources/executeafm/afm/overPeriodDateAttribute.json
+++ b/src/test/resources/executeafm/afm/overPeriodDateAttribute.json
@@ -1,0 +1,6 @@
+{
+  "attribute": {
+    "uri": "/gdc/md/projectId/obj/1"
+  },
+  "periodsAgo": 2
+}

--- a/src/test/resources/executeafm/afm/overPeriodMeasureDefinition.json
+++ b/src/test/resources/executeafm/afm/overPeriodMeasureDefinition.json
@@ -1,0 +1,13 @@
+{
+  "overPeriodMeasure": {
+    "measureIdentifier": "mId",
+    "dateAttributes": [
+      {
+        "attribute": {
+          "uri": "/gdc/md/projectId/obj/1"
+        },
+        "periodsAgo": 2
+      }
+    ]
+  }
+}

--- a/src/test/resources/executeafm/afm/overPeriodMeasureDefinitionWithTwoAttributes.json
+++ b/src/test/resources/executeafm/afm/overPeriodMeasureDefinitionWithTwoAttributes.json
@@ -1,0 +1,19 @@
+{
+  "overPeriodMeasure": {
+    "measureIdentifier": "mId",
+    "dateAttributes": [
+      {
+        "attribute": {
+          "uri": "/gdc/md/projectId/obj/1"
+        },
+        "periodsAgo": 2
+      },
+      {
+        "attribute": {
+          "uri": "/gdc/md/projectId/obj/2"
+        },
+        "periodsAgo": 1
+      }
+    ]
+  }
+}

--- a/src/test/resources/executeafm/afm/popMeasureDefinitionWithOffset.json
+++ b/src/test/resources/executeafm/afm/popMeasureDefinitionWithOffset.json
@@ -1,9 +1,0 @@
-{
-  "popMeasure": {
-    "measureIdentifier": "mId",
-    "popAttribute": {
-      "uri": "/gdc/md/projectId/obj/1"
-    },
-    "offset": -2
-  }
-}

--- a/src/test/resources/executeafm/afm/previousPeriodDateDataSet.json
+++ b/src/test/resources/executeafm/afm/previousPeriodDateDataSet.json
@@ -1,0 +1,6 @@
+{
+  "dataSet": {
+    "uri": "/gdc/md/projectId/obj/1"
+  },
+  "periodsAgo": 2
+}

--- a/src/test/resources/executeafm/afm/previousPeriodMeasureDefinition.json
+++ b/src/test/resources/executeafm/afm/previousPeriodMeasureDefinition.json
@@ -1,0 +1,13 @@
+{
+  "previousPeriodMeasure": {
+    "measureIdentifier": "mId",
+    "dateDataSets": [
+      {
+        "dataSet": {
+          "uri": "/gdc/md/projectId/obj/1"
+        },
+        "periodsAgo": 2
+      }
+    ]
+  }
+}

--- a/src/test/resources/executeafm/afm/previousPeriodMeasureDefinitionWithTwoDataSets.json
+++ b/src/test/resources/executeafm/afm/previousPeriodMeasureDefinitionWithTwoDataSets.json
@@ -1,0 +1,19 @@
+{
+  "previousPeriodMeasure": {
+    "measureIdentifier": "mId",
+    "dateDataSets": [
+      {
+        "dataSet": {
+          "uri": "/gdc/md/projectId/obj/1"
+        },
+        "periodsAgo": 2
+      },
+      {
+        "dataSet": {
+          "uri": "/gdc/md/projectId/obj/2"
+        },
+        "periodsAgo": 1
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The pull request contains two commits:
One for the issue https://github.com/gooddata/gooddata-java/issues/611 that reverts changes introduced via https://github.com/gooddata/gooddata-java/issues/597 and second that supports new PoP implementation reported via https://github.com/gooddata/gooddata-java/issues/612.

The pull request contains changes to the way how measure definitions are copied when they contain identifier object qualifiers. Previously, all the definitions contained 1 object qualifier at maximum. The new definitions can have more of them in its child objects, therefore, the interface of the `MeasureDefinition` had to be changed to reflect this fact. I consulted the change with the late Jan Pradac.

API changes:
```
OverPeriodMeasureDefinition = {
    overPeriodMeasure: {
        measureIdentifier: Identifier, % link to the localIdentifier of existing measure
        dateAttributes : [
            {
                attribute : UriObjQualifier, % date attribute, which is used in MAQL "FOR PREVIOUS" construction as parameter to determine the PoP period
                periodsAgo : INT             % amount of periods the date window specified by the date attribute is offset to the past (positive value) or to the future (negative value). Used as used in MAQL "FOR PREVIOUS" as "periodsAgo" parameter.
            }
        ]
    }
}

PreviousPeriodMeasureDefinition = {
    previousPeriodMeasure: {
        measureIdentifier: Identifier, % link to existing measure
        dateDataSets : [
            {
                dataSet : UriObjQualifier, % date data set that will be found in the AFM date filters and offset by the amount of periods defined by the "periodsAgo" value
                periodsAgo : INT           % amount of periods the date window specified by the date filter identified by the date data set is offset to the past (positive value) or to the future (negative value). Used as used in MAQL "FOR PREVIOUS" as "periodsAgo" parameter.
            }
        ]
    }
}
```