### PR TITLE
Differentiate AttributeContent from Content

### DIFF
--- a/src/main/java/com/gooddata/md/AttributeDisplayForm.java
+++ b/src/main/java/com/gooddata/md/AttributeDisplayForm.java
@@ -5,16 +5,11 @@
  */
 package com.gooddata.md;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.gooddata.util.BooleanDeserializer;
-import com.gooddata.util.BooleanIntegerSerializer;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.gooddata.util.BooleanDeserializer;
+import com.gooddata.util.BooleanIntegerSerializer;
 import com.gooddata.util.GoodDataToStringBuilder;
 
 /**
@@ -27,24 +22,29 @@ public class AttributeDisplayForm extends DisplayForm implements Updatable {
 
     private static final long serialVersionUID = -7903851496647992573L;
 
+    /** @deprecated use {@link #attributeContent} instead */
+    @Deprecated
+    protected final AttributeContent content;
+
     @JsonProperty("content")
-    protected final Content content;
+    protected final AttributeContent attributeContent;
 
     @JsonCreator
-    private AttributeDisplayForm(@JsonProperty("meta") Meta meta, @JsonProperty("content") Content content,
+    private AttributeDisplayForm(@JsonProperty("meta") Meta meta, @JsonProperty("content") AttributeContent content,
             @JsonProperty("links") Links links) {
         super(meta, content, links);
         this.content = content;
+        this.attributeContent = content;
     }
 
     /* Just for serialization test */
     AttributeDisplayForm(String title, String formOf, String expression, boolean isDefault, String ldmExpression, String type, String elements) {
-        this(new Meta(title), new Content(formOf, expression, isDefault, ldmExpression, type), new Links(elements));
+        this(new Meta(title), new AttributeContent(formOf, expression, isDefault, ldmExpression, type), new Links(elements));
     }
 
     @JsonIgnore
     public boolean isDefault() {
-        return Boolean.TRUE.equals(content.isDefault());
+        return Boolean.TRUE.equals(attributeContent.isDefault());
     }
 
     @Override
@@ -53,15 +53,15 @@ public class AttributeDisplayForm extends DisplayForm implements Updatable {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private static class Content extends DisplayForm.Content {
+    private static class AttributeContent extends DisplayForm.Content {
 
         private static final long serialVersionUID = -8502672468934478137L;
         private final boolean isDefault;
 
-        private Content(@JsonProperty("formOf") String formOf, @JsonProperty("expression") String expression,
-                @JsonProperty("default") @JsonDeserialize(using = BooleanDeserializer.class) Boolean isDefault,
-                @JsonProperty("ldmexpression") String ldmExpression,
-                @JsonProperty("type") String type) {
+        private AttributeContent(@JsonProperty("formOf") String formOf, @JsonProperty("expression") String expression,
+                                 @JsonProperty("default") @JsonDeserialize(using = BooleanDeserializer.class) Boolean isDefault,
+                                 @JsonProperty("ldmexpression") String ldmExpression,
+                                 @JsonProperty("type") String type) {
             super(formOf, expression, ldmExpression, type);
             this.isDefault = isDefault;
         }

--- a/src/test/java/com/gooddata/md/AttributeDisplayFormTest.java
+++ b/src/test/java/com/gooddata/md/AttributeDisplayFormTest.java
@@ -18,13 +18,14 @@ import static org.hamcrest.text.MatchesPattern.matchesPattern;
 
 public class AttributeDisplayFormTest {
 
-    public static final String FORM_OF = "/gdc/md/PROJECT_ID/obj/DF_FORM_OF_ID";
-    public static final String EXPRESSION = "[/gdc/md/PROJECT_ID/obj/DF_EXPRESSION_ID]";
-    public static final boolean DEFAULT = false;
-    public static final boolean DEFAULT_TRUE = true;
-    public static final String LDM_EXPRESSION = "";
+    private static final String FORM_OF = "/gdc/md/PROJECT_ID/obj/DF_FORM_OF_ID";
+    private static final String EXPRESSION = "[/gdc/md/PROJECT_ID/obj/DF_EXPRESSION_ID]";
+    private static final boolean DEFAULT = false;
+    private static final boolean DEFAULT_TRUE = true;
+    private static final String LDM_EXPRESSION = "";
     private static final String TYPE = "TYPE";
     private static final String ELEMENTS_LINK = "/gdc/md/PROJECT_ID/obj/DF_ID/elements";
+    private static final String TITLE = "Person Name";
 
     @SuppressWarnings("deprecation")
     @Test
@@ -43,21 +44,21 @@ public class AttributeDisplayFormTest {
 
     @Test
     public void testSerialization() throws Exception {
-        final DisplayForm attrDF = new AttributeDisplayForm("Person Name", FORM_OF, EXPRESSION, DEFAULT,
+        final DisplayForm attrDF = new AttributeDisplayForm(TITLE, FORM_OF, EXPRESSION, DEFAULT,
                 LDM_EXPRESSION, TYPE, ELEMENTS_LINK);
 
         assertThat(attrDF, jsonEquals(resource("md/attributeDisplayForm-input.json")));
     }
 
     @Test
-    public void shouldSerializeSameAsDeserializationInput() throws Exception {
+    public void shouldSerializeSameAsDeserializationInput() {
         final AttributeDisplayForm attrDF = readObjectFromResource("/md/attributeDisplayForm.json", AttributeDisplayForm.class);
         assertThat(attrDF, jsonEquals(resource("md/attributeDisplayForm-inputOrig.json")));
     }
 
     @Test
     public void testToStringFormat() {
-        final DisplayForm attrDF = new AttributeDisplayForm("Person Name", FORM_OF, EXPRESSION, DEFAULT,
+        final DisplayForm attrDF = new AttributeDisplayForm(TITLE, FORM_OF, EXPRESSION, DEFAULT,
                 LDM_EXPRESSION, TYPE, ELEMENTS_LINK);
 
         assertThat(attrDF.toString(), matchesPattern(AttributeDisplayForm.class.getSimpleName() + "\\[.*\\]"));
@@ -65,11 +66,26 @@ public class AttributeDisplayFormTest {
 
     @Test
     public void testSerializable() throws Exception {
-        final DisplayForm attrDF = new AttributeDisplayForm("Person Name", FORM_OF, EXPRESSION, DEFAULT,
+        final DisplayForm attrDF = new AttributeDisplayForm(TITLE, FORM_OF, EXPRESSION, DEFAULT,
                 LDM_EXPRESSION, TYPE, ELEMENTS_LINK);
         final DisplayForm deserialized = SerializationUtils.roundtrip(attrDF);
 
         assertThat(deserialized, jsonEquals(attrDF));
     }
 
+    @Test
+    public void testSubclass() {
+        class Subclass extends AttributeDisplayForm {
+            private Subclass(final String title, final String formOf, final String expression, final boolean isDefault,
+                             final String ldmExpression,
+                             final String type, final String elements) {
+                super(title, formOf, expression, isDefault, ldmExpression, type, elements);
+            }
+        }
+        final Subclass subclass = new Subclass(TITLE, FORM_OF, EXPRESSION, DEFAULT, LDM_EXPRESSION, TYPE,
+                ELEMENTS_LINK);
+
+        //noinspection deprecation
+        assertThat(subclass.content, is(subclass.attributeContent));
+    }
 }


### PR DESCRIPTION
Mainly same field name 'content' as in DisplayForm parent was causing chaos.