### PR TITLE
Simplified VisualizationConverter methods for Execution conversion

### DIFF
--- a/src/main/java/com/gooddata/md/visualization/VisualizationConverter.java
+++ b/src/main/java/com/gooddata/md/visualization/VisualizationConverter.java
@@ -5,6 +5,14 @@
  */
 package com.gooddata.md.visualization;
 
+import static com.gooddata.executeafm.resultspec.Dimension.MEASURE_GROUP;
+import static com.gooddata.md.visualization.CollectionType.SEGMENT;
+import static com.gooddata.md.visualization.CollectionType.STACK;
+import static com.gooddata.md.visualization.CollectionType.TREND;
+import static com.gooddata.md.visualization.CollectionType.VIEW;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.Validate.notNull;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,19 +29,11 @@ import com.gooddata.executeafm.afm.SimpleMeasureDefinition;
 import com.gooddata.executeafm.resultspec.Dimension;
 import com.gooddata.executeafm.resultspec.ResultSpec;
 import com.gooddata.executeafm.resultspec.SortItem;
-
+import com.gooddata.util.Validate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static com.gooddata.executeafm.resultspec.Dimension.MEASURE_GROUP;
-import static com.gooddata.md.visualization.CollectionType.SEGMENT;
-import static com.gooddata.md.visualization.CollectionType.STACK;
-import static com.gooddata.md.visualization.CollectionType.TREND;
-import static com.gooddata.md.visualization.CollectionType.VIEW;
-import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.Validate.notNull;
 
 /**
  * Helper class for converting {@link VisualizationObject} into {@link Execution}
@@ -47,12 +47,26 @@ public abstract class VisualizationConverter {
      * @param visualizationObject which will be converted to {@link Execution}
      * @param visualizationClassGetter {@link Function} for fetching VisualizationClass, which is necessary for correct generation of {@link ResultSpec}
      * @return {@link Execution} object
-     *
-     * @see #convertToAfm(VisualizationObject)
-     * @see #convertToResultSpec(VisualizationObject, Function)
+     * @see #convertToExecution(VisualizationObject, VisualizationClass)
      */
-    public static Execution convertToExecution(final VisualizationObject visualizationObject, final Function<String, VisualizationClass> visualizationClassGetter) {
-        ResultSpec resultSpec = convertToResultSpec(visualizationObject, visualizationClassGetter);
+    public static Execution convertToExecution(final VisualizationObject visualizationObject,
+            final Function<String, VisualizationClass> visualizationClassGetter) {
+        return convertToExecution(visualizationObject,
+                notNull(visualizationClassGetter).apply(notNull(visualizationObject).getVisualizationClassUri()));
+    }
+
+    /**
+     * Generate Execution from Visualization object.
+     *
+     * @param visualizationObject which will be converted to {@link Execution}
+     * @param visualizationClass visualizationClass, which is necessary for correct generation of {@link ResultSpec}
+     * @return {@link Execution} object
+     * @see #convertToAfm(VisualizationObject)
+     * @see #convertToResultSpec(VisualizationObject, VisualizationClass)
+     */
+    public static Execution convertToExecution(final VisualizationObject visualizationObject,
+            final VisualizationClass visualizationClass) {
+        ResultSpec resultSpec = convertToResultSpec(visualizationObject, visualizationClass);
         Afm afm = convertToAfm(visualizationObject);
         return new Execution(afm, resultSpec);
     }
@@ -80,9 +94,24 @@ public abstract class VisualizationConverter {
      * @return {@link Execution} object
      */
     public static ResultSpec convertToResultSpec(final VisualizationObject visualizationObject,
-                                          final Function<String, VisualizationClass> visualizationClassGetter) {
-        VisualizationClass visualizationClass = notNull(visualizationClassGetter).apply(notNull(visualizationObject).getVisualizationClassUri());
+            final Function<String, VisualizationClass> visualizationClassGetter) {
+        return convertToResultSpec(visualizationObject,
+                notNull(visualizationClassGetter).apply(notNull(visualizationObject).getVisualizationClassUri()));
+    }
 
+    /**
+     * Generate ResultSpec from Visualization object. Currently {@link ResultSpec}'s {@link Dimension}s can be generated
+     * for table and four types of chart: bar, column, line and pie.
+     *
+     * @param visualizationObject which will be converted to {@link Execution}
+     * @param visualizationClass VisualizationClass, which is necessary for correct generation of {@link ResultSpec}
+     * @return {@link Execution} object
+     */
+    public static ResultSpec convertToResultSpec(final VisualizationObject visualizationObject,
+            final VisualizationClass visualizationClass) {
+        Validate.isTrue(visualizationObject.getVisualizationClassUri().equals(visualizationClass.getUri()),
+                "visualizationClass URI does not match the URI within visualizationObject, "
+                        + "you're trying to create ResultSpec for incompatible objects");
         List<SortItem> sorts = getSorting(visualizationObject);
         List<Dimension> dimensions = getDimensions(visualizationObject, visualizationClass.getVisualizationType());
         return new ResultSpec(dimensions, sorts);

--- a/src/main/java/com/gooddata/md/visualization/VisualizationConverter.java
+++ b/src/main/java/com/gooddata/md/visualization/VisualizationConverter.java
@@ -10,8 +10,10 @@ import static com.gooddata.md.visualization.CollectionType.SEGMENT;
 import static com.gooddata.md.visualization.CollectionType.STACK;
 import static com.gooddata.md.visualization.CollectionType.TREND;
 import static com.gooddata.md.visualization.CollectionType.VIEW;
+import static com.gooddata.util.Validate.notNull;
+import static com.gooddata.util.Validate.isTrue;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.Validate.notNull;
+
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,7 +31,6 @@ import com.gooddata.executeafm.afm.SimpleMeasureDefinition;
 import com.gooddata.executeafm.resultspec.Dimension;
 import com.gooddata.executeafm.resultspec.ResultSpec;
 import com.gooddata.executeafm.resultspec.SortItem;
-import com.gooddata.util.Validate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -51,8 +52,10 @@ public abstract class VisualizationConverter {
      */
     public static Execution convertToExecution(final VisualizationObject visualizationObject,
             final Function<String, VisualizationClass> visualizationClassGetter) {
+        notNull(visualizationObject, "visualizationObject");
+        notNull(visualizationClassGetter, "visualizationClassGetter");
         return convertToExecution(visualizationObject,
-                notNull(visualizationClassGetter).apply(notNull(visualizationObject).getVisualizationClassUri()));
+                visualizationClassGetter.apply(visualizationObject.getVisualizationClassUri()));
     }
 
     /**
@@ -66,6 +69,8 @@ public abstract class VisualizationConverter {
      */
     public static Execution convertToExecution(final VisualizationObject visualizationObject,
             final VisualizationClass visualizationClass) {
+        notNull(visualizationObject, "visualizationObject");
+        notNull(visualizationClass, "visualizationClass");
         ResultSpec resultSpec = convertToResultSpec(visualizationObject, visualizationClass);
         Afm afm = convertToAfm(visualizationObject);
         return new Execution(afm, resultSpec);
@@ -78,6 +83,7 @@ public abstract class VisualizationConverter {
      * @return {@link Afm} object
      */
     public static Afm convertToAfm(final VisualizationObject visualizationObject) {
+        notNull(visualizationObject, "visualizationObject");
         final List<AttributeItem> attributes = convertAttributes(visualizationObject.getAttributes());
         final List<CompatibilityFilter> filters = convertFilters(visualizationObject.getFilters());
         final List<MeasureItem> measures = convertMeasures(visualizationObject.getMeasures());
@@ -95,8 +101,10 @@ public abstract class VisualizationConverter {
      */
     public static ResultSpec convertToResultSpec(final VisualizationObject visualizationObject,
             final Function<String, VisualizationClass> visualizationClassGetter) {
+        notNull(visualizationObject, "visualizationObject");
+        notNull(visualizationClassGetter, "visualizationClassGetter");
         return convertToResultSpec(visualizationObject,
-                notNull(visualizationClassGetter).apply(notNull(visualizationObject).getVisualizationClassUri()));
+                visualizationClassGetter.apply(visualizationObject.getVisualizationClassUri()));
     }
 
     /**
@@ -109,7 +117,9 @@ public abstract class VisualizationConverter {
      */
     public static ResultSpec convertToResultSpec(final VisualizationObject visualizationObject,
             final VisualizationClass visualizationClass) {
-        Validate.isTrue(visualizationObject.getVisualizationClassUri().equals(visualizationClass.getUri()),
+        notNull(visualizationObject, "visualizationObject");
+        notNull(visualizationClass, "visualizationClass");
+        isTrue(visualizationObject.getVisualizationClassUri().equals(visualizationClass.getUri()),
                 "visualizationClass URI does not match the URI within visualizationObject, "
                         + "you're trying to create ResultSpec for incompatible objects");
         List<SortItem> sorts = getSorting(visualizationObject);

--- a/src/main/java/com/gooddata/md/visualization/VisualizationObject.java
+++ b/src/main/java/com/gooddata/md/visualization/VisualizationObject.java
@@ -288,6 +288,14 @@ public class VisualizationObject extends AbstractObj implements Queryable, Updat
     }
 
     /**
+     * @see VisualizationConverter#convertToExecution(VisualizationObject, VisualizationClass)
+     */
+    @JsonIgnore
+    public Execution convertToExecution(VisualizationClass visualizationClass) {
+        return VisualizationConverter.convertToExecution(this, visualizationClass);
+    }
+
+    /**
      * @see VisualizationConverter#convertToAfm(VisualizationObject)
      */
     @JsonIgnore
@@ -301,6 +309,14 @@ public class VisualizationObject extends AbstractObj implements Queryable, Updat
     @JsonIgnore
     public ResultSpec convertToResultSpec(Function<String, VisualizationClass> visualizationClassgetter) {
         return VisualizationConverter.convertToResultSpec(this, visualizationClassgetter);
+    }
+
+    /**
+     * @see VisualizationConverter#convertToResultSpec(VisualizationObject, VisualizationClass)
+     */
+    @JsonIgnore
+    public ResultSpec convertToResultSpec(VisualizationClass visualizationClass) {
+        return VisualizationConverter.convertToResultSpec(this, visualizationClass);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/groovy/com/gooddata/md/visualization/VisualizationConverterTest.groovy
+++ b/src/test/groovy/com/gooddata/md/visualization/VisualizationConverterTest.groovy
@@ -29,6 +29,7 @@ import java.util.function.Function
 import static VisualizationConverter.convertToAfm
 import static VisualizationConverter.convertToResultSpec
 import static VisualizationConverter.parseSorting
+import static com.gooddata.md.visualization.VisualizationConverter.convertToExecution
 import static com.gooddata.util.ResourceUtils.readObjectFromResource
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals
 import static spock.util.matcher.HamcrestSupport.that
@@ -180,5 +181,57 @@ class VisualizationConverterTest extends Specification {
 
         then:
         thrown(IllegalArgumentException)
+    }
+
+    @Unroll
+    def "should fail if any argument is null in convertToResultSpec(VisualizationObject, VisualizationClass)"() {
+        when:
+        convertToResultSpec(vo, vc)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        vo << [null, Stub(VisualizationObject), null]
+        vc << [null, null, Stub(VisualizationClass)]
+    }
+
+    @Unroll
+    def "should fail if any argument is null in convertToResultSpec(VisualizationObject, Function)"() {
+        when:
+        convertToResultSpec(vo, vcg)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        vo << [null, Stub(VisualizationObject), null]
+        vcg << [null, null, Stub(Function)]
+    }
+
+    @Unroll
+    def "should fail if any argument is null in convertToExecution(VisualizationObject, VisualizationClass)"() {
+        when:
+        convertToExecution(vo, vc)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        vo << [null, Stub(VisualizationObject), null]
+        vc << [null, null, Stub(VisualizationClass)]
+    }
+
+    @Unroll
+    def "should fail if any argument is null in convertToExecution(VisualizationObject, Function)"() {
+        when:
+        convertToExecution(vo, vcg)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        vo << [null, Stub(VisualizationObject), null]
+        vcg << [null, null, Stub(Function)]
     }
 }

--- a/src/test/groovy/com/gooddata/md/visualization/VisualizationConverterTest.groovy
+++ b/src/test/groovy/com/gooddata/md/visualization/VisualizationConverterTest.groovy
@@ -85,8 +85,13 @@ class VisualizationConverterTest extends Specification {
     @Unroll
     def "should generate result spec for table with default sorting from #name"() {
         given:
-        Function getter = { vizObject -> Stub(VisualizationClass) { getVisualizationType() >> VisualizationType.TABLE } }
         VisualizationObject vo = readObjectFromResource("/$resource", VisualizationObject)
+        Function getter = { vizObject ->
+            Stub(VisualizationClass) {
+                getVisualizationType() >> VisualizationType.TABLE
+                getUri() >> vo.getVisualizationClassUri()
+            }
+        }
         ResultSpec converted = convertToResultSpec(vo, getter)
 
         expect:
@@ -107,8 +112,13 @@ class VisualizationConverterTest extends Specification {
     @Unroll
     def "should generate result spec for #type"() {
         given:
-        Function getter = { vizObject -> Stub(VisualizationClass) { getVisualizationType() >> VisualizationType.of(type) } }
         VisualizationObject vo = readObjectFromResource("/$resource", VisualizationObject)
+        Function getter = { vizObject ->
+            Stub(VisualizationClass) {
+                getVisualizationType() >> VisualizationType.of(type)
+                getUri() >> vo.getVisualizationClassUri()
+            }
+        }
         ResultSpec converted = convertToResultSpec(vo, getter)
 
         expect:
@@ -159,5 +169,16 @@ class VisualizationConverterTest extends Specification {
 
         where:
         properties << ['abcd', '{"sortItems":[{"someinvalidstring"}]}']
+    }
+
+    def "should fail when incorrect visualization class is provided"() {
+        when:
+        convertToResultSpec(
+                Stub(VisualizationObject) { getVisualizationClassUri() >> 'visClassUri'},
+                Stub(VisualizationClass) { getUri() >> 'nonMatchingVisClassUri'}
+        )
+
+        then:
+        thrown(IllegalArgumentException)
     }
 }


### PR DESCRIPTION
We wanted to convert objects of VisualizationObject and VisualizationClass that we obtained beforehand, but we were forced to write some boilerplate function that returned the VisualizationClass instead of providing the VisualizationClass directly. The modified methods simply allow to provide the VisualizationClass directly, while still keeping the backward compatibility with previous approach.
In addition, new check was implemented that checks whether the VisualizationClass URI matches with the URI that VisualizationObject contains. If you try to create convert incompatible objects, exception will be thrown.

Fixes #686 