### PR TITLE
Shorten mvn console output in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: java
+# Skip the Travis Installation Phase (installation of dependencies: `mvn install -DskipTests=true`)
 install: true
-script: mvn verify javadoc:javadoc coveralls:report -Pcoverage
+# Customized build command (default is only `mvn test`)
+script: mvn verify javadoc:javadoc coveralls:report -Pcoverage -B -V
 jdk:
   - oraclejdk8
 branches:
   only:
      - master
      - /\d\.0\.0-RC/
+# Cache Maven repo between Travis builds
 cache:
   directories:
     - '$HOME/.m2/repository'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
   only:
      - master
      - /\d\.0\.0-RC/
-sudo: false
 cache:
   directories:
     - '$HOME/.m2/repository'


### PR DESCRIPTION
Add `-B` (non-interactive/batch mode) to hide download progress indication.

Fixes #690 