### PR TITLE
Introduce recovery related fields in Zendesk4ProcessExecution

### DIFF
--- a/src/main/java/com/gooddata/connector/Zendesk4ProcessExecution.java
+++ b/src/main/java/com/gooddata/connector/Zendesk4ProcessExecution.java
@@ -30,6 +30,10 @@ public class Zendesk4ProcessExecution implements ProcessExecution {
 
     private Boolean reload;
 
+    private Boolean recoverable;
+
+    private Boolean recoveryInProgress;
+
     private Map<String, DateTime> startTimes;
 
     private DownloadParams downloadParams;
@@ -56,6 +60,30 @@ public class Zendesk4ProcessExecution implements ProcessExecution {
      */
     public void setReload(final Boolean reload) {
         this.reload = reload;
+    }
+
+    public Boolean getRecoverable() {
+        return recoverable;
+    }
+
+    /**
+     * Tells if the newly started process should use recoverable feature.
+     * Usable from R176.
+     */
+    public void setRecoverable(final Boolean recoverable) {
+        this.recoverable = recoverable;
+    }
+
+    public Boolean getRecoveryInProgress() {
+        return recoveryInProgress;
+    }
+
+    /**
+     * Tells if there is some recoverable process in progress for given project
+     * Usable from R176.
+     */
+    public void setRecoveryInProgress(final Boolean recoveryInProgress) {
+        this.recoveryInProgress = recoveryInProgress;
     }
 
     @JsonAnyGetter

--- a/src/test/java/com/gooddata/connector/Zendesk4ProcessExecutionTest.java
+++ b/src/test/java/com/gooddata/connector/Zendesk4ProcessExecutionTest.java
@@ -52,6 +52,20 @@ public class Zendesk4ProcessExecutionTest {
     }
 
     @Test
+    public void testShouldSerializeRecoverable() {
+        final Zendesk4ProcessExecution execution = new Zendesk4ProcessExecution();
+        execution.setRecoverable(true);
+        assertThat(execution, jsonEquals(resource("connector/process-execution-recoverable.json")));
+    }
+
+    @Test
+    public void testShouldSerializeRecoveryInProgress() {
+        final Zendesk4ProcessExecution execution = new Zendesk4ProcessExecution();
+        execution.setRecoveryInProgress(true);
+        assertThat(execution, jsonEquals(resource("connector/process-execution-recoveryInProgress.json")));
+    }
+
+    @Test
     public void testGetDownloadParams() {
         final Zendesk4ProcessExecution execution = new Zendesk4ProcessExecution();
         final DownloadParams downloadParams = execution.getDownloadParams();

--- a/src/test/resources/connector/process-execution-recoverable.json
+++ b/src/test/resources/connector/process-execution-recoverable.json
@@ -1,0 +1,5 @@
+{
+    "process": {
+        "recoverable": true
+    }
+}

--- a/src/test/resources/connector/process-execution-recoveryInProgress.json
+++ b/src/test/resources/connector/process-execution-recoveryInProgress.json
@@ -1,0 +1,5 @@
+{
+    "process": {
+        "recoveryInProgress": true
+    }
+}


### PR DESCRIPTION
We need to send information if a recovery is in progress ('recoveryInProgress' flag) and if the newly started process should use recoverable feature ('recoverable' flag).

This solves the issue https://github.com/gooddata/gooddata-java/issues/724.