### PR TITLE
Add retry support when GD endpoint is unvailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ The *GoodData Java SDK* uses:
 * the *Slf4j API* version 1.7.*
 * the *Java Development Kit (JDK)* version 8 or later
 
+##### Retry of failed API calls
+
+You can retry your failed requests since version *2.34.0*. Turn it on by configuring
+[RetrySettings](https://github.com/gooddata/gooddata-java/blob/master/src/main/java/com/gooddata/retry/RetrySettings.java)
+and add [Spring retry](https://github.com/spring-projects/spring-retry) to your classpath:
+```xml
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>${spring.retry.version}</version>
+        </dependency>
+```
+
 ### Logging
 
 The *GoodData Java SDK* logs using `slf4j-api`. Please adjust your logging configuration for 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gooddata-java</artifactId>
-    <version>2.33.1-SNAPSHOT</version>
+    <version>2.34.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>GoodData Java SDK</description>
     <url>https://github.com/gooddata/gooddata-java</url>
@@ -309,6 +309,13 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <!-- Required only if you want to use retry of failed requests which is configured in RetrySettings. -->
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>1.2.4.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/com/gooddata/GoodData.java
+++ b/src/main/java/com/gooddata/GoodData.java
@@ -18,6 +18,9 @@ import com.gooddata.lcm.LcmService;
 import com.gooddata.md.maintenance.ExportImportService;
 import com.gooddata.notification.NotificationService;
 import com.gooddata.projecttemplate.ProjectTemplateService;
+import com.gooddata.retry.RetrySettings;
+import com.gooddata.retry.GetServerErrorRetryStrategy;
+import com.gooddata.retry.RetryableRestTemplate;
 import com.gooddata.util.ResponseErrorHandler;
 import com.gooddata.authentication.LoginPasswordAuthentication;
 import com.gooddata.warehouse.WarehouseService;
@@ -38,6 +41,10 @@ import org.apache.http.util.VersionInfo;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestTemplate;
 
@@ -48,7 +55,6 @@ import java.util.Map;
 
 import static com.gooddata.util.Validate.notNull;
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.apache.http.util.VersionInfo.loadVersionInfo;
 
 /**
@@ -216,7 +222,7 @@ public class GoodData {
     protected GoodData(GoodDataEndpoint endpoint, Authentication authentication, GoodDataSettings settings) {
         httpClient = authentication.createHttpClient(endpoint, createHttpClientBuilder(settings));
 
-        restTemplate = createRestTemplate(endpoint, httpClient);
+        restTemplate = createRestTemplate(endpoint, httpClient, settings.getRetrySettings());
 
         accountService = new AccountService(getRestTemplate(), settings);
         projectService = new ProjectService(getRestTemplate(), accountService, settings);
@@ -240,7 +246,7 @@ public class GoodData {
         lcmService = new LcmService(getRestTemplate(), settings);
     }
 
-    static RestTemplate createRestTemplate(GoodDataEndpoint endpoint, HttpClient httpClient) {
+    static RestTemplate createRestTemplate(GoodDataEndpoint endpoint, HttpClient httpClient, RetrySettings retrySettings) {
         notNull(endpoint, "endpoint");
         notNull(httpClient, "httpClient");
 
@@ -253,7 +259,12 @@ public class GoodData {
         presetHeaders.put("Accept", MediaType.APPLICATION_JSON_VALUE);
         presetHeaders.put(Header.GDC_VERSION, readApiVersion());
 
-        final RestTemplate restTemplate = new RestTemplate(factory);
+        final RestTemplate restTemplate;
+        if (retrySettings == null) {
+            restTemplate = new RestTemplate(factory);
+        } else {
+            restTemplate = createRetryRestTemplate(retrySettings, factory);
+        }
         restTemplate.setInterceptors(asList(
                 new HeaderSettingRequestInterceptor(presetHeaders),
                 new DeprecationWarningRequestInterceptor()));
@@ -261,6 +272,30 @@ public class GoodData {
         restTemplate.setErrorHandler(new ResponseErrorHandler(restTemplate.getMessageConverters()));
 
         return restTemplate;
+    }
+
+    private static RestTemplate createRetryRestTemplate(RetrySettings retrySettings, UriPrefixingClientHttpRequestFactory factory) {
+        final RetryTemplate retryTemplate = new RetryTemplate();
+
+        if (retrySettings.getRetryCount() != null) {
+            retryTemplate.setRetryPolicy(new SimpleRetryPolicy(retrySettings.getRetryCount()));
+        }
+
+        if (retrySettings.getRetryInitialInterval() != null) {
+            if (retrySettings.getRetryMultiplier() != null) {
+                final ExponentialBackOffPolicy exponentialBackOffPolicy = new ExponentialBackOffPolicy();
+                exponentialBackOffPolicy.setInitialInterval(retrySettings.getRetryInitialInterval());
+                exponentialBackOffPolicy.setMultiplier(retrySettings.getRetryMultiplier());
+                exponentialBackOffPolicy.setMaxInterval(retrySettings.getRetryMaxInterval());
+                retryTemplate.setBackOffPolicy(exponentialBackOffPolicy);
+            } else {
+                final FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+                backOffPolicy.setBackOffPeriod(retrySettings.getRetryInitialInterval());
+                retryTemplate.setBackOffPolicy(backOffPolicy);
+            }
+        }
+
+        return new RetryableRestTemplate(factory, retryTemplate, new GetServerErrorRetryStrategy());
     }
 
     private HttpClientBuilder createHttpClientBuilder(final GoodDataSettings settings) {

--- a/src/main/java/com/gooddata/GoodDataSettings.java
+++ b/src/main/java/com/gooddata/GoodDataSettings.java
@@ -5,8 +5,10 @@
  */
 package com.gooddata;
 
+import com.gooddata.retry.RetrySettings;
 import com.gooddata.util.GoodDataToStringBuilder;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static org.springframework.util.Assert.isTrue;
@@ -26,6 +28,7 @@ public class GoodDataSettings {
     private int socketTimeout = secondsToMillis(60);
     private int pollSleep = secondsToMillis(5);
     private String userAgent;
+    private RetrySettings retrySettings;
 
 
     /**
@@ -205,30 +208,36 @@ public class GoodDataSettings {
         this.userAgent = userAgent;
     }
 
+    public RetrySettings getRetrySettings() {
+        return retrySettings;
+    }
+
+    /**
+     * Set retry settings
+     * @param retrySettings retry settings
+     */
+    public void setRetrySettings(RetrySettings retrySettings) {
+        this.retrySettings = retrySettings;
+    }
+
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         final GoodDataSettings that = (GoodDataSettings) o;
-
-        if (maxConnections != that.maxConnections) return false;
-        if (connectionTimeout != that.connectionTimeout) return false;
-        if (connectionRequestTimeout != that.connectionRequestTimeout) return false;
-        if (socketTimeout != that.socketTimeout) return false;
-        if (pollSleep != that.pollSleep) return false;
-        return userAgent != null ? userAgent.equals(that.userAgent) : that.userAgent == null;
+        return maxConnections == that.maxConnections
+                && connectionTimeout == that.connectionTimeout
+                && connectionRequestTimeout == that.connectionRequestTimeout
+                && socketTimeout == that.socketTimeout
+                && pollSleep == that.pollSleep
+                && Objects.equals(userAgent, that.userAgent)
+                && Objects.equals(retrySettings, that.retrySettings);
     }
 
     @Override
     public int hashCode() {
-        int result = maxConnections;
-        result = 31 * result + connectionTimeout;
-        result = 31 * result + connectionRequestTimeout;
-        result = 31 * result + socketTimeout;
-        result = 31 * result + pollSleep;
-        result = 31 * result + (userAgent != null ? userAgent.hashCode() : 0);
-        return result;
+        return Objects.hash(maxConnections, connectionTimeout, connectionRequestTimeout, socketTimeout, pollSleep,
+                userAgent, retrySettings);
     }
 
     @Override

--- a/src/main/java/com/gooddata/retry/GetServerErrorRetryStrategy.java
+++ b/src/main/java/com/gooddata/retry/GetServerErrorRetryStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2007-2019, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.retry;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Allows retry for GET method and some HTTP 5XX states mentioned in {@link GetServerErrorRetryStrategy#RETRYABLE_STATES}.
+ */
+public class GetServerErrorRetryStrategy implements RetryStrategy {
+
+    public static final Collection<Integer> RETRYABLE_STATES = Collections.unmodifiableCollection(asList(500, 502, 503, 504, 507));
+    public static final Collection<String> RETRYABLE_METHODS = Collections.unmodifiableCollection(asList("GET"));
+
+    @Override
+    public boolean retryAllowed(String method, int statusCode, URI uri) {
+        return RETRYABLE_STATES.contains(statusCode) && RETRYABLE_METHODS.contains(method);
+    }
+
+}

--- a/src/main/java/com/gooddata/retry/RetrySettings.java
+++ b/src/main/java/com/gooddata/retry/RetrySettings.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2007-2019, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.retry;
+
+import java.util.Objects;
+
+import static org.springframework.util.Assert.isTrue;
+
+/**
+ * Contains settings for HTTP requests retry.
+ */
+public class RetrySettings {
+
+    public Integer DEFAULT_RETRY_COUNT =  6;
+    private Long DEFAULT_RETRY_INITIAL_INTERVAL = 1 * 1000l;  // 1s
+    private Long DEFAULT_RETRY_MAX_INTERVAL = 1 * 60 * 1000l; // 1min
+    private Double DEFAULT_RETRY_MULTIPLIER = 2d;
+
+    private Integer retryCount = DEFAULT_RETRY_COUNT;
+    private Long retryInitialInterval = DEFAULT_RETRY_INITIAL_INTERVAL;
+    private Long retryMaxInterval = DEFAULT_RETRY_MAX_INTERVAL;
+    private Double retryMultiplier = DEFAULT_RETRY_MULTIPLIER;
+
+    /**
+     * Total retry count. Should be > 0. No retry if not set.
+     * @return retry count
+     */
+    public Integer getRetryCount() {
+        return retryCount;
+    }
+
+    public void setRetryCount(Integer retryCount) {
+        isTrue(retryCount == null || retryCount > 0, "retryCount hast to be greater than 0");
+        this.retryCount = retryCount;
+    }
+
+    /**
+     *
+     * @return retry initial interval
+     */
+    public Long getRetryInitialInterval() {
+        return retryInitialInterval;
+    }
+
+    public void setRetryInitialInterval(Long retryInitialInterval) {
+        isTrue(retryInitialInterval > 0, "retryInitialInterval has to be greater than 0");
+        this.retryInitialInterval = retryInitialInterval;
+    }
+
+    /**
+     *
+     * @return maximum retry interval
+     */
+    public Long getRetryMaxInterval() {
+        return retryMaxInterval;
+    }
+
+    public void setRetryMaxInterval(Long retryMaxInterval) {
+        isTrue(retryMaxInterval > 0, "retryMaxInterval has to be greater than 0");
+        this.retryMaxInterval = retryMaxInterval;
+    }
+
+    /**
+     * If set, exponential strategy is used. Every next retry interval will be computed as previos interval multiplied
+     * by this number.
+     * @return retry multiplier
+     */
+    public Double getRetryMultiplier() {
+        return retryMultiplier;
+    }
+
+    public void setRetryMultiplier(Double retryMultiplier) {
+        isTrue(retryMultiplier > 1.0, "retryMultiplier has to be greater than 1.0");
+        this.retryMultiplier = retryMultiplier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RetrySettings that = (RetrySettings) o;
+        return Objects.equals(retryCount, that.retryCount) &&
+                Objects.equals(retryInitialInterval, that.retryInitialInterval) &&
+                Objects.equals(retryMaxInterval, that.retryMaxInterval) &&
+                Objects.equals(retryMultiplier, that.retryMultiplier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(retryCount, retryInitialInterval, retryMaxInterval, retryMultiplier);
+    }
+}

--- a/src/main/java/com/gooddata/retry/RetryStrategy.java
+++ b/src/main/java/com/gooddata/retry/RetryStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2007-2019, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.retry;
+
+import java.net.URI;
+
+/**
+ * Interface for describing retry strategy.
+ */
+public interface RetryStrategy {
+
+    /**
+     * Method says if retry is allowed for given parameter combination.
+     * @param method HTTP method
+     * @param statusCode HTTP response code
+     * @param uri requested URL
+     * @return {@code true} it retry is allowed
+     */
+    boolean retryAllowed(String method, int statusCode, URI uri);
+
+}

--- a/src/main/java/com/gooddata/retry/RetryableRestTemplate.java
+++ b/src/main/java/com/gooddata/retry/RetryableRestTemplate.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.retry;
+
+import com.gooddata.GoodDataRestException;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.client.RequestCallback;
+import org.springframework.web.client.ResponseExtractor;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+/**
+ * REST template with retry ability. Its behavior is described by given strategy and retry template.
+ */
+public class RetryableRestTemplate extends RestTemplate {
+
+    private final RetryTemplate retryTemplate;
+    private final RetryStrategy retryStrategy;
+
+    /**
+     * Create a new instance of the {@link RetryableRestTemplate}.
+     * @param requestFactory HTTP request factory to use
+     * @param retryTemplate retry template
+     * @param retryStrategy retry strategy
+     */
+    public RetryableRestTemplate(ClientHttpRequestFactory requestFactory, RetryTemplate retryTemplate, RetryStrategy retryStrategy) {
+        super(requestFactory);
+        notNull(retryTemplate);
+        this.retryTemplate = retryTemplate;
+        this.retryStrategy = retryStrategy;
+    }
+
+    @Override
+    protected <T> T doExecute(URI url, HttpMethod method, RequestCallback requestCallback,
+                              ResponseExtractor<T> responseExtractor) throws RestClientException {
+        return retryTemplate.execute(context -> {
+            System.out.println("Retrying " + context.getRetryCount() + " " + method + " ");
+            try {
+                return super.doExecute(url, method, requestCallback, responseExtractor);
+            } catch (GoodDataRestException e) {
+                if (!retryStrategy.retryAllowed(method.toString(), e.getStatusCode(), url)) {
+                    context.setExhaustedOnly();
+                }
+                throw e;
+            }
+        });
+    }
+
+}

--- a/src/test/groovy/com/gooddata/retry/RetrySettingsTest.groovy
+++ b/src/test/groovy/com/gooddata/retry/RetrySettingsTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2007-2019, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.retry
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class RetrySettingsTest extends Specification {
+
+    private RetrySettings retrySettings
+
+    def setup() {
+        retrySettings = new RetrySettings()
+    }
+
+    @Unroll
+    def "value #value is #correct for method"() {
+
+        expect:
+        try {
+            retrySettings."set${variable}"(value)
+            assert retrySettings."get${variable}"() == value
+        } catch (IllegalArgumentException e) {
+            assert correct == false
+        }
+        where:
+        value | correct | variable
+         1    | true    | "RetryCount"
+         0    | false   | "RetryCount"
+        -1    | false   | "RetryCount"
+        10    | true    | "RetryCount"
+         0    | false   | "RetryInitialInterval"
+        -1    | false   | "RetryInitialInterval"
+         1    | true    | "RetryInitialInterval"
+        10    | true    | "RetryInitialInterval"
+         0    | false   | "RetryMaxInterval"
+        -1    | false   | "RetryMaxInterval"
+         1    | true    | "RetryMaxInterval"
+        10    | true    | "RetryMaxInterval"
+         1    | false   | "RetryMultiplier"
+         0    | false   | "RetryMultiplier"
+        1.1   | true    | "RetryMultiplier"
+        0.9   | false   | "RetryMultiplier"
+        10    | true    | "RetryMultiplier"
+    }
+
+}

--- a/src/test/groovy/com/gooddata/retry/RetryableRestTemplateTest.groovy
+++ b/src/test/groovy/com/gooddata/retry/RetryableRestTemplateTest.groovy
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2007-2019, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.retry
+
+import com.gooddata.GoodDataException
+import com.gooddata.GoodDataITBase
+import com.gooddata.GoodDataRestException
+import com.gooddata.GoodDataSettings
+import com.gooddata.connector.ConnectorException
+import com.gooddata.connector.ConnectorService
+import com.gooddata.connector.ConnectorType
+import com.gooddata.connector.Integration
+import com.gooddata.project.Project
+import spock.lang.Unroll
+
+import static com.gooddata.util.ResourceUtils.readFromResource
+import static com.gooddata.util.ResourceUtils.readObjectFromResource
+import static net.jadler.Jadler.closeJadler
+import static net.jadler.Jadler.onRequest
+
+class RetryableRestTemplateTest extends GoodDataITBase<ConnectorService> {
+
+    private static final long MIN_NO_RETRY_DURATION = 0l
+    private static final long MAX_NO_RETRY_DURATION = 2000l
+    private static final long MAX_RETRY_DURATION = 10000l
+    private static final long MIN_RETRY_DURATION = 3000l
+
+    @Override
+    protected ConnectorService getService() {
+        return gd.getConnectorService()
+    }
+
+    @Override
+    protected GoodDataSettings createGoodDataSettings() {
+        def retrySettings = new RetrySettings()
+        retrySettings.retryCount = 3
+        retrySettings.retryInitialInterval = 1000
+        retrySettings.retryMaxInterval = 10000
+        retrySettings.retryMultiplier = 2
+
+        def settings = new GoodDataSettings()
+        settings.setRetrySettings(retrySettings)
+        settings.setPollSleep(0)
+        return settings
+    }
+
+    @Unroll
+    def "should retry on #method method and status #errorResponseStatus"() {
+        given:
+        if (method == 'DELETE') {
+            onRequest()
+                    .havingMethodEqualTo("DELETE")
+                    .havingPathEqualTo("/gdc/projects/PROJECT_ID")
+                    .respond()
+                        .withStatus(errorResponseStatus)
+                    .thenRespond()
+                        .withStatus(errorResponseStatus)
+                    .thenRespond()
+                        .withStatus(204)
+        } else if (method == 'GET' && errorResponseStatus == 200) {
+            onRequest()
+                    .havingMethodEqualTo(method)
+                    .havingPathEqualTo("/gdc/projects/PROJECT_ID/connectors/zendesk4/integration")
+                    .respond()
+                        .withBody(readFromResource("/connector/integration.json"))
+                    .thenRespond()
+                        .withStatus(500)
+        } else {
+            onRequest()
+                    .havingMethodEqualTo(method)
+                    .havingPathEqualTo("/gdc/projects/PROJECT_ID/connectors/zendesk4/integration")
+                    .respond()
+                        .withStatus(errorResponseStatus)
+                    .thenRespond()
+                        .withStatus(errorResponseStatus)
+                    .thenRespond()
+                        .withBody(readFromResource("/connector/integration.json"))
+        }
+
+        when:
+        def integration = null
+        def exception = null
+        def startTime = System.currentTimeMillis()
+        try {
+            def project = readObjectFromResource("/project/project.json", Project.class)
+            switch (method) {
+                case "GET":
+                    integration = getService().getIntegration(project, ConnectorType.ZENDESK4)
+                    break
+                case "POST":
+                    integration = getService().createIntegration(project, ConnectorType.ZENDESK4, new Integration("/some/template"))
+                    break
+                case "PUT":
+                    getService().updateIntegration(project, ConnectorType.ZENDESK4, new Integration("/another/template"))
+                    break
+                case "DELETE":
+                    gd.getProjectService().removeProject(project)
+                    break
+                default:
+                    assert false, "Unknown method '${method}'"
+            }
+        } catch (Exception e) {
+            exception = e
+        }
+        def endTime = System.currentTimeMillis()
+        def length = endTime - startTime
+
+        then:
+        length > minTime
+        length < maxTime
+        if (payloadRetrieved) {
+            assert integration != null
+        } else {
+            assert integration == null
+        }
+        if (exceptionClass != null) {
+            assert exception.getClass() == exceptionClass
+        }
+
+        where:
+        method   | errorResponseStatus | payloadRetrieved | exceptionClass        | minTime               | maxTime
+        "GET"    | 200                 | true             | null                  | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+        "GET"    | 400                 | false            | GoodDataRestException | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+        "GET"    | 500                 | true             | null                  | MIN_RETRY_DURATION    | MAX_RETRY_DURATION
+        "GET"    | 501                 | false            | GoodDataRestException | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+        "GET"    | 502                 | true             | null                  | MIN_RETRY_DURATION    | MAX_RETRY_DURATION
+        "GET"    | 503                 | true             | null                  | MIN_RETRY_DURATION    | MAX_RETRY_DURATION
+        "GET"    | 504                 | true             | null                  | MIN_RETRY_DURATION    | MAX_RETRY_DURATION
+        "GET"    | 507                 | true             | null                  | MIN_RETRY_DURATION    | MAX_RETRY_DURATION
+        "POST"   | 501                 | false            | ConnectorException    | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+        "DELETE" | 500                 | false            | GoodDataException     | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+        "DELETE" | 501                 | false            | GoodDataException     | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+        "PUT"    | 500                 | false            | GoodDataRestException | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+        "PUT"    | 501                 | false            | GoodDataRestException | MIN_NO_RETRY_DURATION | MAX_NO_RETRY_DURATION
+    }
+
+    void cleanup() {
+        closeJadler()
+    }
+
+}

--- a/src/test/java/com/gooddata/connector/ConnectorServiceIT.java
+++ b/src/test/java/com/gooddata/connector/ConnectorServiceIT.java
@@ -73,7 +73,7 @@ public class ConnectorServiceIT extends AbstractGoodDataIT {
     }
 
     @Test(expectedExceptions = IntegrationNotFoundException.class)
-    public void shouldFailGetIntegrationNotFount() throws Exception {
+    public void shouldFailGetIntegrationNotFound() throws Exception {
         onRequest()
                 .havingMethodEqualTo("GET")
                 .havingPathEqualTo("/gdc/projects/PROJECT_ID/connectors/zendesk4/integration")


### PR DESCRIPTION
Currently only for GET method and some kinds of HTTP 5XX status.