### PR TITLE
Use OpenJDK instead of Oracle on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: true
 # Customized build command (default is only `mvn test`)
 script: mvn verify javadoc:javadoc coveralls:report -Pcoverage -B -V
 jdk:
-  - oraclejdk8
+  - openjdk8
 branches:
   only:
      - master


### PR DESCRIPTION
https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide/
https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support