### PR TITLE
Add email subject to subscription

### DIFF
--- a/src/main/java/com/gooddata/notification/Subscription.java
+++ b/src/main/java/com/gooddata/notification/Subscription.java
@@ -5,11 +5,13 @@
  */
 package com.gooddata.notification;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -26,6 +28,7 @@ import java.util.stream.Collectors;
 @JsonTypeName("subscription")
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
 public class Subscription {
 
     public static final String URI = "/gdc/projects/{project}/users/{user}/subscriptions";
@@ -33,7 +36,8 @@ public class Subscription {
 
     private final List<Trigger> triggers;
     private final TriggerCondition condition;
-    private final MessageTemplate template;
+    private final MessageTemplate messageTemplate;
+    private final MessageTemplate subjectTemplate;
     private final List<String> channels;
     private final Meta meta;
 
@@ -44,33 +48,55 @@ public class Subscription {
      * @param triggers triggers of subscription
      * @param channels list of {@link Channel}
      * @param condition condition under which this subscription activates
-     * @param template of message
+     * @param messageTemplate of message
      * @param title name of subscription
      */
     public Subscription(final List<Trigger> triggers,
                         final List<Channel> channels,
                         final TriggerCondition condition,
-                        final MessageTemplate template,
+                        final MessageTemplate messageTemplate,
+                        final String title) {
+        this(triggers, channels, condition, messageTemplate, null, title);
+    }
+
+    /**
+     * Creates Subscription
+     *
+     * @param triggers triggers of subscription
+     * @param channels list of {@link Channel}
+     * @param condition condition under which this subscription activates
+     * @param messageTemplate of message
+     * @param subjectTemplate of message
+     * @param title name of subscription
+     */
+    public Subscription(final List<Trigger> triggers,
+                        final List<Channel> channels,
+                        final TriggerCondition condition,
+                        final MessageTemplate messageTemplate,
+                        final MessageTemplate subjectTemplate,
                         final String title) {
         this(notNull(triggers, "triggers"),
-             notNull(condition, "condition"),
-             notNull(template, "template"),
-             notNull(channels, "channels").stream().map(e -> e.getMeta().getUri()).collect(Collectors.toList()),
-             new Meta(
-                     notEmpty(title, "title")
-             )
+                notNull(condition, "condition"),
+                notNull(messageTemplate, "messageTemplate"),
+                subjectTemplate,
+                notNull(channels, "channels").stream().map(e -> e.getMeta().getUri()).collect(Collectors.toList()),
+                new Meta(
+                        notEmpty(title, "title")
+                )
         );
     }
 
     @JsonCreator
     Subscription(@JsonProperty("triggers") final List<Trigger> triggers,
                  @JsonProperty("condition") final TriggerCondition condition,
-                 @JsonProperty("message") final MessageTemplate template,
+                 @JsonProperty("message") final MessageTemplate messageTemplate,
+                 @JsonProperty("subject") final MessageTemplate subjectTemplate,
                  @JsonProperty("channels") final List<String> channels,
                  @JsonProperty("meta") final Meta meta) {
         this.triggers = triggers;
         this.condition = condition;
-        this.template = template;
+        this.messageTemplate = messageTemplate;
+        this.subjectTemplate = subjectTemplate;
         this.channels = channels;
         this.meta = meta;
     }
@@ -85,7 +111,12 @@ public class Subscription {
 
     @JsonProperty("message")
     public MessageTemplate getTemplate() {
-        return template;
+        return messageTemplate;
+    }
+
+    @JsonProperty("subject")
+    public MessageTemplate getSubjectTemplate() {
+        return subjectTemplate;
     }
 
     public List<String> getChannels() {

--- a/src/test/resources/notification/subscriptionWithSubject.json
+++ b/src/test/resources/notification/subscriptionWithSubject.json
@@ -1,0 +1,32 @@
+{
+  "subscription": {
+    "triggers": [
+      {
+        "timerEvent": {
+          "cronExpression": "0 * * * * *"
+        }
+      }
+    ],
+    "condition": {
+      "condition": {
+        "expression": "true"
+      }
+    },
+    "message": {
+      "template": {
+        "expression": "test message"
+      }
+    },
+    "subject": {
+      "template": {
+        "expression": "test subject"
+      }
+    },
+    "channels": [
+      "/gdc/account/profile/876ec68f5630b38de65852ed5d6236ff/channelConfigurations/59dca62e60b2c601f3c72e18"
+    ],
+    "meta": {
+      "title": "test subscription"
+    }
+  }
+}


### PR DESCRIPTION
Currently, it's impossible to specify the subscription email subject, only field for the email body template is defined. The subject added as per documentation.

Fixes https://github.com/gooddata/gooddata-java/issues/842