### PR TITLE
README: show javadoc-model version in its badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GoodData Java SDK
 [![Build Status](https://travis-ci.org/gooddata/gooddata-java.png?branch=master)](https://travis-ci.org/gooddata/gooddata-java)
 [![Javadocs](http://javadoc.io/badge/com.gooddata/gooddata-java.svg)](http://javadoc.io/doc/com.gooddata/gooddata-java)
-[![Javadocs Model](https://img.shields.io/badge/javadoc--model-latest-brightgreen)](https://javadoc.io/doc/com.gooddata/gooddata-java-model)
+[![Javadocs Model](https://javadoc.io/badge2/com.gooddata/gooddata-java-model/javadoc--model.svg)](https://javadoc.io/doc/com.gooddata/gooddata-java-model)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gooddata/gooddata-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gooddata/gooddata-java)
 [![Release](https://img.shields.io/github/release/gooddata/gooddata-java.svg)](https://github.com/gooddata/gooddata-java/releases)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)


### PR DESCRIPTION
The badge URL created according [this issue comment](https://github.com/maxcellent/javadoc.io/issues/45#issuecomment-691733616).