### PR TITLE
#621 - add the logging of requestId (port to 2.35.*)

### DIFF
--- a/src/main/java/com/gooddata/GoodData.java
+++ b/src/main/java/com/gooddata/GoodData.java
@@ -288,6 +288,8 @@ public class GoodData {
 
         return HttpClientBuilder.create()
                 .setUserAgent(StringUtils.isNotBlank(settings.getUserAgent()) ? String.format("%s %s", settings.getUserAgent(), getUserAgent()) : getUserAgent())
+                .addInterceptorFirst(new RequestIdInterceptor())
+                .addInterceptorFirst(new ResponseMissingRequestIdInterceptor())
                 .setConnectionManager(connectionManager)
                 .setDefaultRequestConfig(requestConfig.build());
     }

--- a/src/main/java/com/gooddata/RequestIdInterceptor.java
+++ b/src/main/java/com/gooddata/RequestIdInterceptor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2004-2021, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+
+import static com.gooddata.gdc.Header.GDC_REQUEST_ID;
+
+/**
+ * Intercepts the client-side requests on low-level in order to be able to catch requests also from the Sardine,
+ * that is working independently from Spring {@link org.springframework.web.client.RestTemplate} to set
+ * the X-GDC-REQUEST header to them.
+ */
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
+public class RequestIdInterceptor implements HttpRequestInterceptor {
+
+    @Override
+    public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
+        final StringBuilder requestIdBuilder = new StringBuilder();
+        final Header requestIdHeader = request.getFirstHeader(GDC_REQUEST_ID);
+        if (requestIdHeader != null) {
+            requestIdBuilder.append(requestIdHeader.getValue()).append(":");
+        }
+        final String requestId = requestIdBuilder.append(RandomStringUtils.randomAlphanumeric(16)).toString();
+        request.setHeader(GDC_REQUEST_ID, requestId);
+    }
+}

--- a/src/main/java/com/gooddata/ResponseMissingRequestIdInterceptor.java
+++ b/src/main/java/com/gooddata/ResponseMissingRequestIdInterceptor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2004-2021, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata;
+
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+
+import java.io.IOException;
+
+import static com.gooddata.gdc.Header.GDC_REQUEST_ID;
+
+
+/**
+ * Intercepts responses to check if they have set the X-GDC-REQUEST header for easier debugging.
+ * If not, it takes this header from the request sent.
+ */
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
+public class ResponseMissingRequestIdInterceptor implements HttpResponseInterceptor {
+
+    @Override
+    public void process(final HttpResponse response, final HttpContext context) throws HttpException, IOException {
+
+        if (response.getFirstHeader(GDC_REQUEST_ID) == null) {
+            final HttpCoreContext coreContext = HttpCoreContext.adapt(context);
+            final Header requestIdHeader = coreContext.getRequest().getFirstHeader(GDC_REQUEST_ID);
+            response.setHeader(GDC_REQUEST_ID, requestIdHeader.getValue());
+        }
+    }
+}

--- a/src/main/java/com/gooddata/gdc/GdcSardine.java
+++ b/src/main/java/com/gooddata/gdc/GdcSardine.java
@@ -8,11 +8,18 @@ package com.gooddata.gdc;
 import static com.gooddata.util.Validate.notNull;
 
 import com.github.sardine.impl.SardineImpl;
+import com.github.sardine.impl.io.ContentLengthInputStream;
+import com.github.sardine.impl.io.HttpMethodReleaseInputStream;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class extends SardineImpl, connections were not correctly closed by parent
@@ -28,11 +35,41 @@ class GdcSardine extends SardineImpl {
      */
     @Override
     protected <T> T execute(HttpRequestBase request, ResponseHandler<T> responseHandler) throws IOException {
-        notNull(request,"request");
+        notNull(request, "request");
         try {
             return super.execute(request, responseHandler);
         } finally {
             request.releaseConnection();
+        }
+    }
+
+    /**
+     * The method body is retrieved from {@link SardineImpl#get(String, Map)} and extended about the response handler
+     * to be able to handle responses arbitrarily.
+     *
+     * @param url             Path to the resource including protocol and hostname
+     * @param headers         Additional HTTP headers to add to the request
+     * @param responseHandler Arbitrary response handler to manipulate with responses
+     * @return Data stream to read from
+     * @throws IOException I/O error or HTTP response validation failure
+     */
+    public <T> ContentLengthInputStream get(final String url, final List<Header> headers, final
+    ResponseHandler<T> responseHandler) throws IOException {
+
+        final HttpGet get = new HttpGet(url);
+        for (Header header : headers) {
+            get.addHeader(header);
+        }
+        // Must use #execute without handler, otherwise the entity is consumed
+        // already after the handler exits.
+        final HttpResponse response = this.execute(get);
+        try {
+            responseHandler.handleResponse(response);
+            // Will abort the read when closed before EOF.
+            return new ContentLengthInputStream(new HttpMethodReleaseInputStream(response), response.getEntity().getContentLength());
+        } catch (IOException ex) {
+            get.abort();
+            throw ex;
         }
     }
 }

--- a/src/main/java/com/gooddata/gdc/GdcSardineException.java
+++ b/src/main/java/com/gooddata/gdc/GdcSardineException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2007-2021, GoodData(R) Corporation. All rights reserved.
+ */
+package com.gooddata.gdc;
+
+import com.github.sardine.impl.SardineException;
+
+/**
+ * Extended Sardine exception about X-GDC-REQUEST header value.
+ */
+public class GdcSardineException extends SardineException {
+
+    private final String requestId;
+
+    /**
+     * @param msg            Custom description of failure
+     * @param statusCode     Error code returned by server
+     * @param responsePhrase Response phrase following the error code
+     * @param requestId      The X-GDC-REQUEST identifier.
+     */
+    public GdcSardineException(String requestId, String msg, int statusCode, String responsePhrase) {
+        super(msg, statusCode, responsePhrase);
+        this.requestId = requestId;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("[request_id=%s]: %s (%d %s)", this.requestId, super.getMessage(), this.getStatusCode(),
+                this.getResponsePhrase()
+        );
+    }
+
+}

--- a/src/main/java/com/gooddata/gdc/GdcSardineResponseHandler.java
+++ b/src/main/java/com/gooddata/gdc/GdcSardineResponseHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2004-2021, GoodData(R) Corporation. All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+package com.gooddata.gdc;
+
+import com.github.sardine.impl.SardineException;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ResponseHandler;
+
+import java.io.IOException;
+
+import static com.gooddata.gdc.Header.GDC_REQUEST_ID;
+
+
+/**
+ * A basic validation response handler that extends the functionality of {@link com.github.sardine.impl.handler.ValidatingResponseHandler}
+ * about the addition of X-GDC-REQUEST header to exception.
+ */
+class GdcSardineResponseHandler implements ResponseHandler<Void> {
+
+    @Override
+    public Void handleResponse(final HttpResponse response) throws IOException {
+        final StatusLine statusLine = response.getStatusLine();
+        final int statusCode = statusLine.getStatusCode();
+        if (statusCode >= HttpStatus.SC_OK && statusCode < HttpStatus.SC_MULTIPLE_CHOICES) {
+            return null;
+        }
+        final Header requestIdHeader = response.getFirstHeader(GDC_REQUEST_ID);
+        if (requestIdHeader != null) {
+            throw new GdcSardineException(requestIdHeader.getValue(), "Unexpected response", statusLine.getStatusCode(),
+                    statusLine.getReasonPhrase()
+            );
+        } else {
+            throw new SardineException("Unexpected response", statusLine.getStatusCode(), statusLine.getReasonPhrase());
+        }
+    }
+}


### PR DESCRIPTION
Added 'RequestIdInterceptor' on the apache http client to generate 'requestId' for the client requests. It wasn't added to Spring 'RestTemplate' because the Sardine client doesn't use it.

Added 'ResponseMissingRequestIdInterceptor' on the apache http client to add missing 'X-GDC-REQUEST' header in responses coming from WebDav server.

Added the 'requestId' information to exceptions to easier tracking the problem.