### PR TITLE
Deprecate getEventStores links

### DIFF
--- a/gooddata-java-model/src/main/java/com/gooddata/sdk/model/project/Project.java
+++ b/gooddata-java-model/src/main/java/com/gooddata/sdk/model/project/Project.java
@@ -206,7 +206,11 @@ public class Project {
         return notNullState(links, "links").getExecute();
     }
 
+    /**
+     * @deprecated This service has been removed from platform long time ago.
+     */
     @JsonIgnore
+    @Deprecated
     public String getEventStoresUri() {
         return notNullState(links, "links").getEventStores();
     }
@@ -469,6 +473,10 @@ public class Project {
             return execute;
         }
 
+        /**
+         * @deprecated This service has been removed from platform long time ago.
+         */
+        @Deprecated
         public String getEventStores() {
             return eventStores;
         }

--- a/gooddata-java-model/src/test/java/com/gooddata/sdk/model/project/ProjectTest.java
+++ b/gooddata-java-model/src/test/java/com/gooddata/sdk/model/project/ProjectTest.java
@@ -58,7 +58,6 @@ public class ProjectTest {
         assertThat(project.getExecuteUri(), is("/gdc/projects/PROJECT_ID/execute"));
         assertThat(project.getSchedulesUri(), is("/gdc/projects/PROJECT_ID/schedules"));
         assertThat(project.getTemplatesUri(), is("/gdc/md/PROJECT_ID/templates"));
-        assertThat(project.getEventStoresUri(), is("/gdc/projects/PROJECT_ID/dataload/eventstore/stores"));
     }
 
     @Test

--- a/gooddata-java-model/src/test/resources/project/project-vertica.json
+++ b/gooddata-java-model/src/test/resources/project/project-vertica.json
@@ -24,8 +24,7 @@
             "connectors" : "/gdc/projects/PROJECT_ID/connectors",
             "execute" : "/gdc/projects/PROJECT_ID/execute",
             "schedules" : "/gdc/projects/PROJECT_ID/schedules",
-            "templates" : "/gdc/md/PROJECT_ID/templates",
-            "eventstores" : "/gdc/projects/PROJECT_ID/dataload/eventstore/stores"
+            "templates" : "/gdc/md/PROJECT_ID/templates"
         },
         "meta" : {
             "created" : "2014-04-11 11:43:45",

--- a/gooddata-java-model/src/test/resources/project/project.json
+++ b/gooddata-java-model/src/test/resources/project/project.json
@@ -25,8 +25,7 @@
             "connectors" : "/gdc/projects/PROJECT_ID/connectors",
             "execute" : "/gdc/projects/PROJECT_ID/execute",
             "schedules" : "/gdc/projects/PROJECT_ID/schedules",
-            "templates" : "/gdc/md/PROJECT_ID/templates",
-            "eventstores" : "/gdc/projects/PROJECT_ID/dataload/eventstore/stores"
+            "templates" : "/gdc/md/PROJECT_ID/templates"
         },
         "meta" : {
             "created" : "2014-04-11 11:43:45",

--- a/gooddata-java-model/src/test/resources/project/projects.json
+++ b/gooddata-java-model/src/test/resources/project/projects.json
@@ -41,7 +41,6 @@
                         "connectors": "/gdc/projects/defaultEmptyProject/connectors",
                         "schedules": "/gdc/projects/defaultEmptyProject/schedules",
                         "dataload": "/gdc/projects/defaultEmptyProject/dataload",
-                        "eventstores": "/gdc/projects/defaultEmptyProject/dataload/eventstore/stores",
                         "execute": "/gdc/projects/defaultEmptyProject/execute",
                         "clearCaches": "/gdc/projects/defaultEmptyProject/clearCaches",
                         "projectFeatureFlags": "/gdc/projects/defaultEmptyProject/projectFeatureFlags",

--- a/gooddata-java/src/test/resources/project/project-deleted.json
+++ b/gooddata-java/src/test/resources/project/project-deleted.json
@@ -22,8 +22,7 @@
             "connectors": "/gdc/projects/PROJECT_ID/connectors",
             "execute": "/gdc/projects/PROJECT_ID/execute",
             "schedules": "/gdc/projects/PROJECT_ID/schedules",
-            "templates": "/gdc/md/PROJECT_ID/templates",
-            "eventstores": "/gdc/projects/PROJECT_ID/dataload/eventstore/stores"
+            "templates": "/gdc/md/PROJECT_ID/templates"
         },
         "meta": {
             "created": "2014-06-06 19:54:16",

--- a/gooddata-java/src/test/resources/project/project-loading.json
+++ b/gooddata-java/src/test/resources/project/project-loading.json
@@ -22,8 +22,7 @@
             "connectors": "/gdc/projects/PROJECT_ID/connectors",
             "execute": "/gdc/projects/PROJECT_ID/execute",
             "schedules": "/gdc/projects/PROJECT_ID/schedules",
-            "templates": "/gdc/md/PROJECT_ID/templates",
-            "eventstores": "/gdc/projects/PROJECT_ID/dataload/eventstore/stores"
+            "templates": "/gdc/md/PROJECT_ID/templates"
         },
         "meta": {
             "created": "2014-06-06 19:54:16",

--- a/gooddata-java/src/test/resources/project/project-vertica.json
+++ b/gooddata-java/src/test/resources/project/project-vertica.json
@@ -24,8 +24,7 @@
             "connectors" : "/gdc/projects/PROJECT_ID/connectors",
             "execute" : "/gdc/projects/PROJECT_ID/execute",
             "schedules" : "/gdc/projects/PROJECT_ID/schedules",
-            "templates" : "/gdc/md/PROJECT_ID/templates",
-            "eventstores" : "/gdc/projects/PROJECT_ID/dataload/eventstore/stores"
+            "templates" : "/gdc/md/PROJECT_ID/templates"
         },
         "meta" : {
             "created" : "2014-04-11 11:43:45",

--- a/gooddata-java/src/test/resources/project/project.json
+++ b/gooddata-java/src/test/resources/project/project.json
@@ -25,8 +25,7 @@
             "connectors" : "/gdc/projects/PROJECT_ID/connectors",
             "execute" : "/gdc/projects/PROJECT_ID/execute",
             "schedules" : "/gdc/projects/PROJECT_ID/schedules",
-            "templates" : "/gdc/md/PROJECT_ID/templates",
-            "eventstores" : "/gdc/projects/PROJECT_ID/dataload/eventstore/stores"
+            "templates" : "/gdc/md/PROJECT_ID/templates"
         },
         "meta" : {
             "created" : "2014-04-11 11:43:45",

--- a/gooddata-java/src/test/resources/project/projects-for-user.json
+++ b/gooddata-java/src/test/resources/project/projects-for-user.json
@@ -41,7 +41,6 @@
             "connectors": "/gdc/projects/defaultEmptyProject/connectors",
             "schedules": "/gdc/projects/defaultEmptyProject/schedules",
             "dataload": "/gdc/projects/defaultEmptyProject/dataload",
-            "eventstores": "/gdc/projects/defaultEmptyProject/dataload/eventstore/stores",
             "execute": "/gdc/projects/defaultEmptyProject/execute",
             "clearCaches": "/gdc/projects/defaultEmptyProject/clearCaches",
             "checkXaeCompatibility": "/gdc/projects/defaultEmptyProject/checkXaeCompatibility",

--- a/gooddata-java/src/test/resources/project/projects-for-user.json
+++ b/gooddata-java/src/test/resources/project/projects-for-user.json
@@ -43,7 +43,6 @@
             "dataload": "/gdc/projects/defaultEmptyProject/dataload",
             "execute": "/gdc/projects/defaultEmptyProject/execute",
             "clearCaches": "/gdc/projects/defaultEmptyProject/clearCaches",
-            "checkXaeCompatibility": "/gdc/projects/defaultEmptyProject/checkXaeCompatibility",
             "projectFeatureFlags": "/gdc/projects/defaultEmptyProject/projectFeatureFlags",
             "config": "/gdc/projects/defaultEmptyProject/config"
           }


### PR DESCRIPTION
This service has been removed from platform long time ago and
those links are not on the API anymore.