### PR TITLE
Introduce totals support in visualizations and their conversions

### DIFF
--- a/gooddata-java-model/src/main/java/com/gooddata/sdk/model/md/visualization/Bucket.java
+++ b/gooddata-java-model/src/main/java/com/gooddata/sdk/model/md/visualization/Bucket.java
@@ -11,8 +11,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.gooddata.sdk.model.executeafm.afm.LocallyIdentifiable;
+import com.gooddata.sdk.model.executeafm.resultspec.TotalItem;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -26,17 +28,33 @@ public class Bucket implements Serializable, LocallyIdentifiable {
     private static final long serialVersionUID = -7718720886547680021L;
     private final String localIdentifier;
     private final List<BucketItem> items;
+    private final List<TotalItem> totals;
+
+    /**
+     * Creates new instance of bucket without totals
+     *
+     * @param localIdentifier local identifier of bucket
+     * @param items           list of {@link BucketItem}s for this bucket
+     */
+    public Bucket(@JsonProperty("localIdentifier") final String localIdentifier,
+            @JsonProperty("items") final List<BucketItem> items) {
+        this(localIdentifier, items, null);
+    }
 
     /**
      * Creates new instance of bucket
+     *
      * @param localIdentifier local identifier of bucket
-     * @param items list of {@link BucketItem}s for this bucket
+     * @param items           list of {@link BucketItem}s for this bucket
+     * @param totals          list of {@link TotalItem}s for this bucket
      */
     @JsonCreator
     public Bucket(@JsonProperty("localIdentifier") final String localIdentifier,
-                  @JsonProperty("items") final List<BucketItem> items) {
+            @JsonProperty("items") final List<BucketItem> items,
+            @JsonProperty("totals") List<TotalItem> totals) {
         this.localIdentifier = localIdentifier;
         this.items = items;
+        this.totals = totals;
     }
 
     /**
@@ -53,6 +71,13 @@ public class Bucket implements Serializable, LocallyIdentifiable {
         return items;
     }
 
+    /**
+     * @return list of defined {@link TotalItem}s
+     */
+    public List<TotalItem> getTotals() {
+        return totals;
+    }
+
     @JsonIgnore
     VisualizationAttribute getOnlyAttribute() {
         if (getItems() != null && getItems().size() == 1) {
@@ -67,15 +92,18 @@ public class Bucket implements Serializable, LocallyIdentifiable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         Bucket bucket = (Bucket) o;
-        return Objects.equals(localIdentifier, bucket.localIdentifier) &&
-                Objects.equals(items, bucket.items);
+        return Objects.equals(localIdentifier, bucket.localIdentifier)
+                && Objects.equals(items, bucket.items)
+                && Objects.equals(totals, bucket.totals);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(localIdentifier, items);
+        return Objects.hash(localIdentifier, items, totals);
     }
 }

--- a/gooddata-java-model/src/main/java/com/gooddata/sdk/model/md/visualization/VisualizationObject.java
+++ b/gooddata-java-model/src/main/java/com/gooddata/sdk/model/md/visualization/VisualizationObject.java
@@ -24,6 +24,7 @@ import com.gooddata.sdk.model.executeafm.afm.Afm;
 import com.gooddata.sdk.model.executeafm.Execution;
 import com.gooddata.sdk.model.executeafm.afm.filter.ExtendedFilter;
 import com.gooddata.sdk.model.executeafm.resultspec.ResultSpec;
+import com.gooddata.sdk.model.executeafm.resultspec.TotalItem;
 import com.gooddata.sdk.model.md.AbstractObj;
 import com.gooddata.sdk.model.md.Meta;
 import com.gooddata.sdk.model.md.Queryable;
@@ -75,6 +76,14 @@ public class VisualizationObject extends AbstractObj implements Queryable, Updat
     @JsonIgnore
     public List<Measure> getMeasures() {
         return content.getMeasures();
+    }
+
+    /**
+     * @return all totals from all buckets in visualization object
+     */
+    @JsonIgnore
+    public List<TotalItem> getTotals() {
+        return content.getTotals();
     }
 
     /**
@@ -388,6 +397,14 @@ public class VisualizationObject extends AbstractObj implements Queryable, Updat
                     .flatMap(bucket -> bucket.getItems().stream())
                     .filter(Measure.class::isInstance)
                     .map(Measure.class::cast)
+                    .collect(toList());
+        }
+
+        @JsonIgnore
+        public List<TotalItem> getTotals() {
+            return buckets.stream()
+                    .filter(bucket -> bucket.getTotals() != null)
+                    .flatMap(bucket -> bucket.getTotals().stream())
                     .collect(toList());
         }
 

--- a/gooddata-java-model/src/main/java/com/gooddata/sdk/model/md/visualization/VisualizationObject.java
+++ b/gooddata-java-model/src/main/java/com/gooddata/sdk/model/md/visualization/VisualizationObject.java
@@ -33,6 +33,7 @@ import com.gooddata.sdk.model.md.*;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -223,6 +224,14 @@ public class VisualizationObject extends AbstractObj implements Queryable, Updat
     @JsonIgnore
     public void setBuckets(List<Bucket> buckets) {
         content.setBuckets(buckets);
+    }
+
+    /**
+     * @return a new copy of this {@link VisualizationObject} with the specified buckets
+     */
+    @JsonIgnore
+    public VisualizationObject withBuckets(List<Bucket> buckets) {
+        return new VisualizationObject(content.withBuckets(buckets), meta);
     }
 
     /**
@@ -432,6 +441,20 @@ public class VisualizationObject extends AbstractObj implements Queryable, Updat
         @JsonProperty("references")
         public Map<String, String> getReferenceItems() {
             return referenceItems;
+        }
+
+        /**
+         * @return a new copy of this {@link Content} with the specified buckets
+         */
+        @JsonIgnore
+        public Content withBuckets(List<Bucket> buckets) {
+            return new Content(
+                    visualizationClass,
+                    buckets,
+                    filters != null ? new ArrayList<>(filters) : null,
+                    properties,
+                    referenceItems != null ? new HashMap<>(referenceItems) : null
+            );
         }
     }
 }

--- a/gooddata-java-model/src/test/groovy/com/gooddata/sdk/model/md/visualization/BucketTest.groovy
+++ b/gooddata-java-model/src/test/groovy/com/gooddata/sdk/model/md/visualization/BucketTest.groovy
@@ -6,6 +6,8 @@
 package com.gooddata.sdk.model.md.visualization
 
 import com.gooddata.sdk.model.executeafm.UriObjQualifier
+import com.gooddata.sdk.model.executeafm.resultspec.TotalItem
+import com.gooddata.sdk.model.md.report.Total
 import nl.jqno.equalsverifier.EqualsVerifier
 import org.apache.commons.lang3.SerializationUtils
 import spock.lang.Shared
@@ -18,6 +20,7 @@ import static spock.util.matcher.HamcrestSupport.that
 class BucketTest extends Specification {
     private static final String NO_ITEMS_BUCKET = "md/visualization/noItemsBucket.json"
     private static final String MIXED_BUCKET = "md/visualization/mixedBucket.json"
+    private static final String MIXED_BUCKET_WITH_TOTALS = "md/visualization/mixedBucketWithTotals.json"
     private static final String ATTRIBUTE_BUCKET = "md/visualization/attributeBucket.json"
     private static final String MEASURE_BUCKET = "md/visualization/measureBucket.json"
     private static final String MULTIPLE_ATTRIBUTES_BUCKET = "md/visualization/multipleAttributesBucket.json"
@@ -32,19 +35,41 @@ class BucketTest extends Specification {
         that new Bucket("noItems", new ArrayList<BucketItem>()), jsonEquals(noItemsBucket)
     }
 
-    @SuppressWarnings("GrDeprecatedAPIUsage")
     def "should serialize full"() {
         expect:
-        that new Bucket("attributeBucket", [
-                new VisualizationAttribute(new UriObjQualifier("/uri/to/displayForm"), "attribute", "Attribute Alias"),
-                new Measure(
-                        new VOSimpleMeasureDefinition(new UriObjQualifier("/uri/to/measure"), "sum", false, []),
-                        "measure",
-                        "Measure Alias",
-                        "Measure",
-                        null
-                )
-        ]), jsonEquals(mixedBucket)
+        that new Bucket(
+                "attributeBucket",
+                [
+                        new VisualizationAttribute(new UriObjQualifier("/uri/to/displayForm"), "attribute", "Attribute Alias"),
+                        new Measure(
+                                new VOSimpleMeasureDefinition(new UriObjQualifier("/uri/to/measure"), "sum", false, []),
+                                "measure",
+                                "Measure Alias",
+                                "Measure",
+                                null
+                        )
+                ] as List<BucketItem>
+        ), jsonEquals(mixedBucket)
+    }
+
+    def "should serialize full with totals"() {
+        expect:
+        that new Bucket(
+                "attributeBucket",
+                [
+                        new VisualizationAttribute(new UriObjQualifier("/uri/to/displayForm"), "attribute", "Attribute Alias"),
+                        new Measure(
+                                new VOSimpleMeasureDefinition(new UriObjQualifier("/uri/to/measure"), "sum", false, []),
+                                "measure",
+                                "Measure Alias",
+                                "Measure",
+                                null
+                        )
+                ] as List<BucketItem>,
+                [
+                        new TotalItem("measure", Total.NAT, "attribute")
+                ]
+        ), jsonEquals(readObjectFromResource("/$MIXED_BUCKET_WITH_TOTALS", Bucket.class))
     }
 
     def "should return only attribute from bucket"() {

--- a/gooddata-java-model/src/test/resources/executeafm/afm/complextTableWithTotalsConvertedAfm.json
+++ b/gooddata-java-model/src/test/resources/executeafm/afm/complextTableWithTotalsConvertedAfm.json
@@ -1,0 +1,85 @@
+{
+  "measures": [
+    {
+      "localIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+      "definition": {
+        "measureDefinition": {
+          "filters": [],
+          "item": {
+            "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/9211"
+          }
+        }
+      },
+      "alias": "_Close [BOP]"
+    }
+  ],
+  "attributes": [
+    {
+      "displayForm": {
+        "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1024"
+      },
+      "localIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4"
+    },
+    {
+      "displayForm": {
+        "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1028"
+      },
+      "localIdentifier": "9008f5d33b3e41279402a25e2f05d0c9"
+    },
+    {
+      "displayForm": {
+        "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1086"
+      },
+      "localIdentifier": "023641d306f84921be39d0aa1d6464db"
+    },
+    {
+      "displayForm": {
+        "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1805"
+      },
+      "localIdentifier": "a22843f5d77f48b4938ccfb460eb8be4"
+    },
+    {
+      "displayForm": {
+        "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1094"
+      },
+      "localIdentifier": "a77983fcc9574f6bad6be1d3cb08bf71"
+    }
+  ],
+  "nativeTotals": [
+    {
+      "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+      "attributeIdentifiers": []
+    },
+    {
+      "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+      "attributeIdentifiers": [
+        "e4bb25477bca4fb2a29a4b80d94568d4"
+      ]
+    },
+    {
+      "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+      "attributeIdentifiers": [
+        "e4bb25477bca4fb2a29a4b80d94568d4",
+        "9008f5d33b3e41279402a25e2f05d0c9"
+      ]
+    },
+    {
+      "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+      "attributeIdentifiers": [
+        "e4bb25477bca4fb2a29a4b80d94568d4",
+        "9008f5d33b3e41279402a25e2f05d0c9",
+        "023641d306f84921be39d0aa1d6464db"
+      ]
+    },
+    {
+      "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+      "attributeIdentifiers": [
+        "e4bb25477bca4fb2a29a4b80d94568d4",
+        "9008f5d33b3e41279402a25e2f05d0c9",
+        "023641d306f84921be39d0aa1d6464db",
+        "a22843f5d77f48b4938ccfb460eb8be4"
+      ]
+    }
+  ],
+  "filters":[]
+}

--- a/gooddata-java-model/src/test/resources/executeafm/executionComplexTableConverted.json
+++ b/gooddata-java-model/src/test/resources/executeafm/executionComplexTableConverted.json
@@ -1,0 +1,147 @@
+{
+  "execution": {
+    "afm": {
+      "attributes": [
+        {
+          "displayForm": {
+            "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1024"
+          },
+          "localIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4"
+        },
+        {
+          "displayForm": {
+            "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1028"
+          },
+          "localIdentifier": "9008f5d33b3e41279402a25e2f05d0c9"
+        },
+        {
+          "displayForm": {
+            "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1086"
+          },
+          "localIdentifier": "023641d306f84921be39d0aa1d6464db"
+        },
+        {
+          "displayForm": {
+            "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1805"
+          },
+          "localIdentifier": "a22843f5d77f48b4938ccfb460eb8be4"
+        },
+        {
+          "displayForm": {
+            "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1094"
+          },
+          "localIdentifier": "a77983fcc9574f6bad6be1d3cb08bf71"
+        }
+      ],
+      "filters": [],
+      "measures": [
+        {
+          "definition": {
+            "measureDefinition": {
+              "item": {
+                "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/9211"
+              },
+              "filters": []
+            }
+          },
+          "localIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+          "alias": "_Close [BOP]"
+        }
+      ],
+      "nativeTotals": [
+        {
+          "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+          "attributeIdentifiers": []
+        },
+        {
+          "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+          "attributeIdentifiers": [
+            "e4bb25477bca4fb2a29a4b80d94568d4"
+          ]
+        },
+        {
+          "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+          "attributeIdentifiers": [
+            "e4bb25477bca4fb2a29a4b80d94568d4",
+            "9008f5d33b3e41279402a25e2f05d0c9"
+          ]
+        },
+        {
+          "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+          "attributeIdentifiers": [
+            "e4bb25477bca4fb2a29a4b80d94568d4",
+            "9008f5d33b3e41279402a25e2f05d0c9",
+            "023641d306f84921be39d0aa1d6464db"
+          ]
+        },
+        {
+          "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+          "attributeIdentifiers": [
+            "e4bb25477bca4fb2a29a4b80d94568d4",
+            "9008f5d33b3e41279402a25e2f05d0c9",
+            "023641d306f84921be39d0aa1d6464db",
+            "a22843f5d77f48b4938ccfb460eb8be4"
+          ]
+        }
+      ]
+    },
+    "resultSpec": {
+      "dimensions": [
+        {
+          "itemIdentifiers": [
+            "e4bb25477bca4fb2a29a4b80d94568d4",
+            "9008f5d33b3e41279402a25e2f05d0c9",
+            "023641d306f84921be39d0aa1d6464db",
+            "a22843f5d77f48b4938ccfb460eb8be4",
+            "a77983fcc9574f6bad6be1d3cb08bf71"
+          ],
+          "totals": [
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "type": "nat",
+              "attributeIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4"
+            },
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "type": "nat",
+              "attributeIdentifier": "9008f5d33b3e41279402a25e2f05d0c9"
+            },
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "type": "nat",
+              "attributeIdentifier": "a22843f5d77f48b4938ccfb460eb8be4"
+            },
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "type": "nat",
+              "attributeIdentifier": "a77983fcc9574f6bad6be1d3cb08bf71"
+            },
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "type": "sum",
+              "attributeIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4"
+            },
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "type": "nat",
+              "attributeIdentifier": "023641d306f84921be39d0aa1d6464db"
+            }
+          ]
+        },
+        {
+          "itemIdentifiers": [
+            "measureGroup"
+          ]
+        }
+      ],
+      "sorts": [
+        {
+          "attributeSortItem": {
+            "direction": "asc",
+            "attributeIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/gooddata-java-model/src/test/resources/md/visualization/complexTableWithTotals.json
+++ b/gooddata-java-model/src/test/resources/md/visualization/complexTableWithTotals.json
@@ -1,0 +1,117 @@
+{
+  "visualizationObject": {
+    "content": {
+      "buckets": [
+        {
+          "localIdentifier": "measures",
+          "items": [
+            {
+              "measure": {
+                "definition": {
+                  "measureDefinition": {
+                    "item": {
+                      "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/9211"
+                    }
+                  }
+                },
+                "title": "_Close [BOP]",
+                "localIdentifier": "fd0164f14ec2444b9b5a7140ce059036"
+              }
+            }
+          ]
+        },
+        {
+          "items": [
+            {
+              "visualizationAttribute": {
+                "displayForm": {
+                  "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1024"
+                },
+                "localIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4"
+              }
+            },
+            {
+              "visualizationAttribute": {
+                "displayForm": {
+                  "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1028"
+                },
+                "localIdentifier": "9008f5d33b3e41279402a25e2f05d0c9"
+              }
+            },
+            {
+              "visualizationAttribute": {
+                "displayForm": {
+                  "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1086"
+                },
+                "localIdentifier": "023641d306f84921be39d0aa1d6464db"
+              }
+            }
+          ],
+          "totals": [
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "attributeIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4",
+              "type": "sum"
+            },
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "attributeIdentifier": "e4bb25477bca4fb2a29a4b80d94568d4",
+              "type": "nat"
+            },
+            {
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "attributeIdentifier": "9008f5d33b3e41279402a25e2f05d0c9",
+              "type": "nat"
+            },
+            {
+              "attributeIdentifier": "023641d306f84921be39d0aa1d6464db",
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036",
+              "type": "nat"
+            }
+          ],
+          "localIdentifier": "attribute"
+        },
+        {
+          "items": [
+            {
+              "visualizationAttribute": {
+                "localIdentifier": "a22843f5d77f48b4938ccfb460eb8be4",
+                "displayForm": {
+                  "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1805"
+                }
+              }
+            },
+            {
+              "visualizationAttribute": {
+                "localIdentifier": "a77983fcc9574f6bad6be1d3cb08bf71",
+                "displayForm": {
+                  "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/1094"
+                }
+              }
+            }
+          ],
+          "totals": [
+            {
+              "type": "nat",
+              "attributeIdentifier": "a22843f5d77f48b4938ccfb460eb8be4",
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036"
+            },
+            {
+              "type": "nat",
+              "attributeIdentifier": "a77983fcc9574f6bad6be1d3cb08bf71",
+              "measureIdentifier": "fd0164f14ec2444b9b5a7140ce059036"
+            }
+          ],
+          "localIdentifier": "columns"
+        }
+      ],
+      "properties": "{\"sortItems\":[{\"attributeSortItem\":{\"attributeIdentifier\":\"e4bb25477bca4fb2a29a4b80d94568d4\",\"direction\":\"asc\"}}]}",
+      "visualizationClass": {
+        "uri": "/gdc/md/w3hub93g7fwmvx60pkt2v8cr56530t0l/obj/75547"
+      }
+    },
+    "meta": {
+      "title": "complex-with-totals"
+    }
+  }
+}

--- a/gooddata-java-model/src/test/resources/md/visualization/mixedBucketWithTotals.json
+++ b/gooddata-java-model/src/test/resources/md/visualization/mixedBucketWithTotals.json
@@ -1,0 +1,37 @@
+{
+  "localIdentifier": "attributeBucket",
+  "items": [
+    {
+      "visualizationAttribute": {
+        "localIdentifier": "attribute",
+        "displayForm": {
+          "uri": "/uri/to/displayForm"
+        },
+        "alias": "Attribute Alias"
+      }
+    }, {
+      "measure": {
+        "localIdentifier": "measure",
+        "title": "Measure",
+        "alias": "Measure Alias",
+        "definition": {
+          "measureDefinition": {
+            "item": {
+              "uri": "/uri/to/measure"
+            },
+            "aggregation": "sum",
+            "computeRatio": false,
+            "filters": []
+          }
+        }
+      }
+    }
+  ],
+  "totals": [
+    {
+      "measureIdentifier": "measure",
+      "type": "nat",
+      "attributeIdentifier": "attribute"
+    }
+  ]
+}


### PR DESCRIPTION
* Introduces `totals` field in the visualization `Bucket`
* Adds new AFM execution conversion methods with totals support:
  * `VisualizationConverter.convertToResultSpecWithTotals`
  * `VisualizationConverter.convertToAfmWithNativeTotals`
  * `VisualizationConverter.convertToExecutionWithTotals`
* Keeps old conversion methods (without `totals` support) for the backward-compatibility.